### PR TITLE
Implement support for shield powerup

### DIFF
--- a/protocol-common/src/enums/command_reply_type.rs
+++ b/protocol-common/src/enums/command_reply_type.rs
@@ -1,9 +1,38 @@
 use specs::DenseVecStorage;
 
-impl_try_from_enum! {
-	/// TODO: Reverse engineer
-	#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-	#[cfg_attr(feature = "specs", derive(Component))]
-	#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-	pub enum CommandReplyType {}
+use std::convert::From;
+
+/// TODO: Reverse engineer
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "specs", derive(Component))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum CommandReplyType {
+	ShowInConsole = 0,
+	/// Technically this should be any value other than 0,
+	/// the from integer implementation for this enum deals
+	/// with that.
+	ShowInPopup = 1,
 }
+
+macro_rules! decl_from {
+	($ty:ty) => {
+		impl From<$ty> for CommandReplyType {
+			fn from(v: $ty) -> Self {
+				match v {
+					0 => CommandReplyType::ShowInConsole,
+					_ => CommandReplyType::ShowInPopup,
+				}
+			}
+		}
+
+		impl From<CommandReplyType> for $ty {
+			fn from(v: CommandReplyType) -> $ty {
+				v as $ty
+			}
+		}
+	};
+}
+
+decl_from!(u8);
+decl_from!(u16);
+decl_from!(u32);

--- a/protocol-common/src/enums/powerup_type.rs
+++ b/protocol-common/src/enums/powerup_type.rs
@@ -7,5 +7,8 @@ impl_try_from_enum! {
 	#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 	pub enum PowerupType {
 		Shield = 1,
+		/// This is just a guess.
+		/// TODO: Verify
+		Inferno = 2,
 	}
 }

--- a/protocol-common/src/enums/powerup_type.rs
+++ b/protocol-common/src/enums/powerup_type.rs
@@ -5,5 +5,7 @@ impl_try_from_enum! {
 	#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 	#[cfg_attr(feature = "specs", derive(Component))]
 	#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-	pub enum PowerupType {}
+	pub enum PowerupType {
+		Shield = 1,
+	}
 }

--- a/protocol-common/src/packets/client/command.rs
+++ b/protocol-common/src/packets/client/command.rs
@@ -4,8 +4,8 @@
 ///
 /// # Changing a flag
 /// ```
-/// # extern crate airmash_protocol;
-/// # use airmash_protocol::client::Command;
+/// # extern crate protocol_common;
+/// # use protocol_common::client::Command;
 /// # fn main() {
 /// let cmd = Command {
 ///     com: "flag".to_string(),
@@ -21,8 +21,8 @@
 ///
 /// # Respawning as a plane
 /// ```
-/// # extern crate airmash_protocol;
-/// # use airmash_protocol::client::Command;
+/// # extern crate protocol_common;
+/// # use protocol_common::client::Command;
 /// # fn main() {
 /// let cmd = Command {
 ///     com: "respawn".to_string(),
@@ -39,8 +39,8 @@
 ///
 /// # Selecting Upgrades
 /// ```
-/// # extern crate airmash_protocol;
-/// # use airmash_protocol::client::Command;
+/// # extern crate protocol_common;
+/// # use protocol_common::client::Command;
 /// # fn main() {
 /// let cmd = Command {
 ///     com: "upgrade".to_string(),
@@ -55,8 +55,8 @@
 ///
 /// # Going into spectate or spectating a different player
 /// ```
-/// # extern crate airmash_protocol;
-/// # use airmash_protocol::client::Command;
+/// # extern crate protocol_common;
+/// # use protocol_common::client::Command;
 /// # fn main() {
 /// let cmd = Command {
 ///     com: "spectate".to_string(),

--- a/protocol-v5/src/error.rs
+++ b/protocol-v5/src/error.rs
@@ -157,6 +157,18 @@ impl From<EnumValueOutOfRangeError<u16>> for DeserializeError {
 	}
 }
 
+impl From<!> for DeserializeError {
+	fn from(never: !) -> Self {
+		never
+	}
+}
+
+impl From<!> for SerializeError {
+	fn from(never: !) -> Self {
+		never
+	}
+}
+
 fn append_to<T>(mut v: Vec<T>, elem: T) -> Vec<T> {
 	v.push(elem);
 	v

--- a/protocol-v5/src/funcs/low_res_pos.rs
+++ b/protocol-v5/src/funcs/low_res_pos.rs
@@ -7,7 +7,7 @@ pub fn serialize(pos: &Option<Position>, ser: &mut Serializer) -> Result<(), Ser
 		.map(|v| ((v.x.inner() / 128.0) as i32 + 128) as u8)
 		.unwrap_or(0);
 	let y = pos
-		.map(|v| ((v.y.inner() / 64.0) as i32 + 120) as u8)
+		.map(|v| ((v.y.inner() / 64.0) as i32 + 128) as u8)
 		.unwrap_or(0);
 
 	(x, y).serialize(ser)

--- a/protocol-v5/src/lib.rs
+++ b/protocol-v5/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(try_from)]
+#![feature(try_from, never_type)]
 
 extern crate protocol_common;
 

--- a/server/src/component/channel.rs
+++ b/server/src/component/channel.rs
@@ -41,6 +41,7 @@ pub type OnPlayerMuted = EventChannel<PlayerMute>;
 pub type OnPlayerThrottled = EventChannel<PlayerThrottle>;
 pub type OnPlayerHit = EventChannel<PlayerHit>;
 pub type OnPowerupExpired = EventChannel<PowerupExpired>;
+pub type OnPlayerPowerup = EventChannel<PlayerPowerup>;
 
 // Upgrade Events
 pub type OnUpgradeSpawn = EventChannel<UpgradeSpawnEvent>;
@@ -90,6 +91,7 @@ pub type OnPlayerMutedReader = ReaderId<PlayerMute>;
 pub type OnPlayerThrottledReader = ReaderId<PlayerThrottle>;
 pub type OnPlayerHitReader = ReaderId<PlayerHit>;
 pub type OnPowerupExpiredReader = ReaderId<PowerupExpired>;
+pub type OnPlayerPowerupReader = ReaderId<PlayerPowerup>;
 
 // Upgrade Events
 pub type OnUpgradePickupReader = ReaderId<UpgradePickupEvent>;

--- a/server/src/component/channel.rs
+++ b/server/src/component/channel.rs
@@ -40,6 +40,7 @@ pub type OnPlayerRepel = EventChannel<PlayerRepel>;
 pub type OnPlayerMuted = EventChannel<PlayerMute>;
 pub type OnPlayerThrottled = EventChannel<PlayerThrottle>;
 pub type OnPlayerHit = EventChannel<PlayerHit>;
+pub type OnPowerupExpired = EventChannel<PowerupExpired>;
 
 // Upgrade Events
 pub type OnUpgradeSpawn = EventChannel<UpgradeSpawnEvent>;
@@ -88,6 +89,7 @@ pub type OnPlayerRepelReader = ReaderId<PlayerRepel>;
 pub type OnPlayerMutedReader = ReaderId<PlayerMute>;
 pub type OnPlayerThrottledReader = ReaderId<PlayerThrottle>;
 pub type OnPlayerHitReader = ReaderId<PlayerHit>;
+pub type OnPowerupExpiredReader = ReaderId<PowerupExpired>;
 
 // Upgrade Events
 pub type OnUpgradePickupReader = ReaderId<UpgradePickupEvent>;

--- a/server/src/component/event.rs
+++ b/server/src/component/event.rs
@@ -4,7 +4,7 @@ use std::any::Any;
 use std::time::Instant;
 
 use protocol::client::*;
-use protocol::FlagCode;
+use protocol::{FlagCode, PowerupType};
 use types::collision::Collision;
 pub use types::event::{ConnectionClose, ConnectionOpen, Message};
 use types::*;
@@ -144,6 +144,12 @@ pub struct UpgradeSpawnEvent {
 #[derive(Copy, Clone, Debug)]
 pub struct UpgradeDespawnEvent {
 	pub upgrade: Entity,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct PowerupExpired {
+	pub player: Entity,
+	pub ty: PowerupType,
 }
 
 impl Default for TimerEvent {

--- a/server/src/component/event.rs
+++ b/server/src/component/event.rs
@@ -1,7 +1,7 @@
 use specs::*;
 
 use std::any::Any;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use protocol::client::*;
 use protocol::{FlagCode, PowerupType};
@@ -149,6 +149,13 @@ pub struct UpgradeDespawnEvent {
 #[derive(Copy, Clone, Debug)]
 pub struct PowerupExpired {
 	pub player: Entity,
+	pub ty: PowerupType,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct PlayerPowerup {
+	pub player: Entity,
+	pub duration: Duration,
 	pub ty: PowerupType,
 }
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(optin_builtin_traits, try_from)]
+#![feature(optin_builtin_traits, try_from, try_trait)]
 
 // Crates with macros
 #[macro_use]

--- a/server/src/systems/admin/give_powerup.rs
+++ b/server/src/systems/admin/give_powerup.rs
@@ -1,0 +1,197 @@
+use specs::*;
+use types::*;
+
+use utils::event_handler::{EventHandler, EventHandlerTypeProvider};
+
+use component::channel::OnPlayerPowerup;
+use component::event::{CommandEvent, PlayerPowerup};
+
+use protocol::server::CommandReply;
+use protocol::{CommandReplyType, PowerupType};
+
+use std::convert::TryFrom;
+use std::option::NoneError;
+
+#[derive(Debug)]
+enum CommandParseError<'a> {
+	NoSuchPlayer(u16),
+	InvalidPlayerId(&'a str),
+	InvalidPowerupType(u8),
+	InvalidPowerupName(&'a str),
+	MissingArguments,
+}
+
+impl<'a> From<NoneError> for CommandParseError<'a> {
+	fn from(_: NoneError) -> Self {
+		CommandParseError::MissingArguments
+	}
+}
+
+fn collect_fixed<I, T>(mut iter: I) -> Option<[T; 2]>
+where
+	I: Iterator<Item = T>,
+{
+	Some([iter.next()?, iter.next()?])
+}
+
+fn parse_powerup<'a>(ident: &'a str) -> Result<PowerupType, CommandParseError<'a>> {
+	let res: Result<u8, _> = ident.parse();
+	match res {
+		Ok(u) => match PowerupType::try_from(u) {
+			Ok(p) => Ok(p),
+			Err(_) => Err(CommandParseError::InvalidPowerupType(u)),
+		},
+		Err(_) => Ok(match ident {
+			"inferno" => PowerupType::Inferno,
+			"shield" => PowerupType::Shield,
+			_ => return Err(CommandParseError::InvalidPowerupName(ident)),
+		}),
+	}
+}
+
+fn parse_id<'a>(ident: &'a str) -> Result<u16, CommandParseError<'a>> {
+	ident
+		.parse()
+		.map_err(|_| CommandParseError::InvalidPlayerId(ident))
+}
+
+fn parse_command_iter<'a, I>(iter: I) -> Result<(PowerupType, u16), CommandParseError<'a>>
+where
+	I: Iterator<Item = &'a str>,
+{
+	let vals = collect_fixed(iter)?;
+
+	Ok((parse_powerup(vals[0])?, parse_id(vals[1])?))
+}
+
+#[derive(Default)]
+pub struct GivePowerup;
+
+#[derive(SystemData)]
+pub struct GivePowerupData<'a> {
+	entities: Entities<'a>,
+	channel: Write<'a, OnPlayerPowerup>,
+	config: Read<'a, Config>,
+	conns: Read<'a, Connections>,
+}
+
+impl GivePowerup {
+	fn do_command<'a, 'b>(
+		evt: &'b CommandEvent,
+		data: &mut GivePowerupData<'a>,
+	) -> Result<(), CommandParseError<'b>> {
+		use self::PowerupType::*;
+
+		let &(conn, ref packet) = evt;
+
+		if !data.config.admin_enabled {
+			return Ok(());
+		}
+
+		if packet.com != "give-powerup" {
+			return Ok(());
+		}
+
+		if data.conns.associated_player(conn).is_none() {
+			return Ok(());
+		}
+
+		let (ty, id) = parse_command_iter(packet.data.split(" "))?;
+		let player = data.entities.entity(id as u32);
+
+		if !data.entities.is_alive(player) {
+			return Err(CommandParseError::NoSuchPlayer(id));
+		}
+
+		let duration = match ty {
+			Shield => data.config.shield_duration,
+			Inferno => data.config.inferno_duration,
+		};
+
+		data.channel.single_write(PlayerPowerup {
+			player,
+			duration,
+			ty,
+		});
+
+		Ok(())
+	}
+}
+
+impl EventHandlerTypeProvider for GivePowerup {
+	type Event = CommandEvent;
+}
+
+impl<'a> EventHandler<'a> for GivePowerup {
+	type SystemData = GivePowerupData<'a>;
+
+	fn on_event(&mut self, evt: &CommandEvent, data: &mut Self::SystemData) {
+		if let Err(e) = Self::do_command(evt, data) {
+			let (conn, _) = evt;
+			data.conns.send_to(
+				*conn,
+				CommandReply {
+					ty: CommandReplyType::ShowInPopup,
+					text: format!("{:#?}", e),
+				},
+			);
+		}
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	#[test]
+	fn test_inferno_success() {
+		let terms: Vec<&str> = vec!["inferno", "1"];
+
+		let (ty, id) = parse_command_iter(terms.into_iter()).expect("Command failed to parse");
+
+		assert_eq!(ty, PowerupType::Inferno);
+		assert_eq!(id, 1);
+	}
+
+	#[test]
+	fn test_shield_success() {
+		let terms: Vec<&str> = vec!["shield", "230"];
+
+		let (ty, id) = parse_command_iter(terms.into_iter()).expect("Command failed to parse");
+
+		assert_eq!(ty, PowerupType::Shield);
+		assert_eq!(id, 230);
+	}
+
+	#[test]
+	fn test_invalid_powerup_type_ident() {
+		let terms: Vec<&str> = vec!["bork5", "32"];
+
+		let res = parse_command_iter(terms.into_iter());
+
+		assert!(res.is_err());
+
+		if let Err(e) = res {
+			match e {
+				CommandParseError::InvalidPowerupName(name) => assert_eq!(name, "bork5"),
+				_ => panic!("Incorrect error returned {:?}", e),
+			}
+		}
+	}
+
+	#[test]
+	fn test_invalid_powerup_type_num() {
+		let terms: Vec<&str> = vec!["255", "8988"];
+
+		let res = parse_command_iter(terms.into_iter());
+
+		if let Err(e) = res {
+			match e {
+				CommandParseError::InvalidPowerupType(v) => assert_eq!(v, 255),
+				_ => panic!("Incorrect error returned {:?}", e),
+			}
+		} else {
+			panic!("Parsing should not have succeeded. Result: {:?}", res);
+		}
+	}
+}

--- a/server/src/systems/admin/mod.rs
+++ b/server/src/systems/admin/mod.rs
@@ -1,5 +1,6 @@
 mod register;
 
+mod give_powerup;
 mod spawn_upgrade;
 
 pub use self::register::register;

--- a/server/src/systems/handlers/game/mod.rs
+++ b/server/src/systems/handlers/game/mod.rs
@@ -11,6 +11,7 @@ pub mod on_missile_fire;
 pub mod on_player_hit;
 pub mod on_player_killed;
 pub mod on_player_respawn;
+pub mod on_powerup_expire;
 pub mod on_spectate_event;
 pub mod timer;
 

--- a/server/src/systems/handlers/game/on_join/mod.rs
+++ b/server/src/systems/handlers/game/on_join/mod.rs
@@ -12,6 +12,7 @@ mod init_transform;
 mod send_level;
 mod send_login;
 mod send_player_new;
+mod send_player_powerup;
 mod send_score;
 mod update_players_game;
 
@@ -29,6 +30,7 @@ pub use self::init_transform::InitTransform;
 pub use self::send_level::SendPlayerLevel;
 pub use self::send_login::SendLogin;
 pub use self::send_player_new::SendPlayerNew;
+pub use self::send_player_powerup::SendPlayerPowerup;
 pub use self::send_score::SendScoreUpdate;
 pub use self::update_players_game::UpdatePlayersGame;
 
@@ -49,4 +51,5 @@ pub type AllJoinHandlers = (
 	SendPlayerNew,
 	SendScoreUpdate,
 	UpdatePlayersGame,
+	SendPlayerPowerup,
 );

--- a/server/src/systems/handlers/game/on_join/send_login.rs
+++ b/server/src/systems/handlers/game/on_join/send_login.rs
@@ -55,8 +55,8 @@ impl SendLogin {
 				|(ent, pos, rot, plane, name, flag, upgrades, level, status, team, powerups)| {
 					let upgrade_field = ProtocolUpgrades {
 						speed: upgrades.speed,
-						shield: powerups.shield,
-						inferno: powerups.inferno,
+						shield: powerups.shield(),
+						inferno: powerups.inferno(),
 					};
 
 					LoginPlayer {

--- a/server/src/systems/handlers/game/on_join/send_player_new.rs
+++ b/server/src/systems/handlers/game/on_join/send_player_new.rs
@@ -57,8 +57,8 @@ impl<'a> System<'a> for SendPlayerNew {
 
 			let upgrades = ProtocolUpgrades {
 				speed: upgrades.get(evt.id).unwrap().speed,
-				inferno: powerups.inferno,
-				shield: powerups.shield,
+				inferno: powerups.inferno(),
+				shield: powerups.shield(),
 			};
 
 			let player_new = PlayerNew {

--- a/server/src/systems/handlers/game/on_join/send_player_powerup.rs
+++ b/server/src/systems/handlers/game/on_join/send_player_powerup.rs
@@ -1,0 +1,67 @@
+use specs::*;
+
+use types::{Config, Connections, PowerupDetails};
+use SystemInfo;
+
+use component::event::PlayerJoin;
+use component::time::ThisFrame;
+
+use protocol::server::PlayerPowerup;
+use protocol::PowerupType;
+
+use types::Powerups;
+use utils::event_handler::{EventHandler, EventHandlerTypeProvider};
+
+/// Add the initial 2s shield when a player joins
+/// and send that packet to all visible players.
+#[derive(Default)]
+pub struct SendPlayerPowerup;
+
+#[derive(SystemData)]
+pub struct SendPlayerPowerupData<'a> {
+	conns: Read<'a, Connections>,
+	config: Read<'a, Config>,
+	this_frame: Read<'a, ThisFrame>,
+
+	powerups: WriteStorage<'a, Powerups>,
+}
+
+impl EventHandlerTypeProvider for SendPlayerPowerup {
+	type Event = PlayerJoin;
+}
+
+impl<'a> EventHandler<'a> for SendPlayerPowerup {
+	type SystemData = SendPlayerPowerupData<'a>;
+
+	fn on_event(&mut self, evt: &PlayerJoin, data: &mut Self::SystemData) {
+		let powerup = data.powerups.get_mut(evt.id).unwrap();
+
+		powerup.details = Some(PowerupDetails {
+			ty: PowerupType::Shield,
+			end_time: data.this_frame.0 + data.config.spawn_shield_duration,
+		});
+
+		let duration = data.config.spawn_shield_duration.as_secs() * 1000
+			+ data.config.spawn_shield_duration.subsec_millis() as u64;
+
+		data.conns.send_to_visible(
+			evt.id,
+			PlayerPowerup {
+				duration: duration as u32,
+				ty: PowerupType::Shield,
+			},
+		);
+	}
+}
+
+impl SystemInfo for SendPlayerPowerup {
+	type Dependencies = (super::InitState,);
+
+	fn name() -> &'static str {
+		concat!(module_path!(), "::", line!())
+	}
+
+	fn new() -> Self {
+		Self::default()
+	}
+}

--- a/server/src/systems/handlers/game/on_player_hit/inflict_damage.rs
+++ b/server/src/systems/handlers/game/on_player_hit/inflict_damage.rs
@@ -56,7 +56,7 @@ impl<'a> EventHandler<'a> for InflictDamage {
 		let ref upgconf = data.config.upgrades;
 
 		// No damage can be done if the player is shielded
-		if powerups.shield {
+		if powerups.shield() {
 			return;
 		}
 

--- a/server/src/systems/handlers/game/on_player_hit/inflict_damage.rs
+++ b/server/src/systems/handlers/game/on_player_hit/inflict_damage.rs
@@ -27,6 +27,7 @@ pub struct InflictDamageData<'a> {
 	pub upgrades: ReadStorage<'a, Upgrades>,
 	pub owner: ReadStorage<'a, PlayerRef>,
 	pub player_flag: ReadStorage<'a, IsPlayer>,
+	pub powerups: ReadStorage<'a, Powerups>,
 
 	pub mob: ReadStorage<'a, Mob>,
 	pub pos: ReadStorage<'a, Position>,
@@ -52,6 +53,7 @@ impl<'a> System<'a> for InflictDamage {
 			let plane = data.plane.get(evt.player).unwrap();
 			let health = data.health.get_mut(evt.player).unwrap();
 			let upgrades = data.upgrades.get(evt.player).unwrap();
+			let powerups = data.powerups.get(evt.player).unwrap();
 
 			let mob = data.mob.get(evt.missile).unwrap();
 			let pos = data.pos.get(evt.missile).unwrap();
@@ -60,6 +62,11 @@ impl<'a> System<'a> for InflictDamage {
 			let ref planeconf = data.config.planes[*plane];
 			let ref mobconf = data.config.mobs[*mob].missile.unwrap();
 			let ref upgconf = data.config.upgrades;
+
+			// No damage can be done if the player is shielded
+			if powerups.shield {
+				continue;
+			}
 
 			*health -= mobconf.damage * planeconf.damage_factor
 				/ upgconf.defense.factor[upgrades.defense as usize];

--- a/server/src/systems/handlers/game/on_powerup_expire/force_update.rs
+++ b/server/src/systems/handlers/game/on_powerup_expire/force_update.rs
@@ -1,0 +1,50 @@
+use specs::*;
+use types::systemdata::*;
+
+use SystemInfo;
+
+use utils::event_handler::{EventHandler, EventHandlerTypeProvider};
+
+use component::event::PowerupExpired;
+use component::time::{LastUpdate, StartTime};
+
+#[derive(Default)]
+pub struct ForceUpdate;
+
+#[derive(SystemData)]
+pub struct ForceUpdateData<'a> {
+	is_alive: IsAlive<'a>,
+	game_start: Read<'a, StartTime>,
+
+	last_update: WriteStorage<'a, LastUpdate>,
+}
+
+impl EventHandlerTypeProvider for ForceUpdate {
+	type Event = PowerupExpired;
+}
+
+impl<'a> EventHandler<'a> for ForceUpdate {
+	type SystemData = ForceUpdateData<'a>;
+
+	fn on_event(&mut self, evt: &Self::Event, data: &mut Self::SystemData) {
+		if !data.is_alive.get(evt.player) {
+			return;
+		}
+
+		data.last_update.get_mut(evt.player).unwrap().0 = data.game_start.0;
+	}
+}
+
+impl SystemInfo for ForceUpdate {
+	// This system has no dependencies, and it doesn't really matter
+	// if it happens one frame, or the next.
+	type Dependencies = ();
+
+	fn name() -> &'static str {
+		concat!(module_path!(), "::", line!())
+	}
+
+	fn new() -> Self {
+		Self::default()
+	}
+}

--- a/server/src/systems/handlers/game/on_powerup_expire/mod.rs
+++ b/server/src/systems/handlers/game/on_powerup_expire/mod.rs
@@ -1,0 +1,3 @@
+mod force_update;
+
+pub use self::force_update::ForceUpdate;

--- a/server/src/systems/handlers/game/register.rs
+++ b/server/src/systems/handlers/game/register.rs
@@ -30,6 +30,7 @@ pub fn register<'a, 'b>(builder: Builder<'a, 'b>) -> Builder<'a, 'b> {
 		.with::<on_join::SendPlayerLevel>()
 		.with::<on_join::SendScoreUpdate>()
 		.with::<on_join::UpdatePlayersGame>()
+		.with_handler::<on_join::SendPlayerPowerup>()
 		// On player leave
 		.with::<on_leave::FreeName>()
 		.with::<on_leave::UpdatePlayersGame>()
@@ -43,8 +44,12 @@ pub fn register<'a, 'b>(builder: Builder<'a, 'b>) -> Builder<'a, 'b> {
 		.with::<on_player_respawn::ResetKeyState>()
 		.with::<on_player_respawn::SetTraits>()
 		.with::<on_player_respawn::SendPlayerRespawn>()
-		// Needs to be after InflictDamage
+		// Misc
 		.with::<PlayerKilledCleanup>()
+		// Chat throttling
 		.with_registrar(on_chat_throttled::register)
+		// Timer events
 		.with_registrar(timer::register)
+		// Powerup expiry
+		.with_handler::<on_powerup_expire::ForceUpdate>()
 }

--- a/server/src/systems/handlers/game/register.rs
+++ b/server/src/systems/handlers/game/register.rs
@@ -37,7 +37,7 @@ pub fn register<'a, 'b>(builder: Builder<'a, 'b>) -> Builder<'a, 'b> {
 		.with::<on_missile_fire::SendPlayerFire>()
 		.with::<on_missile_fire::SetLastShot>()
 		// On player hit
-		.with::<on_player_hit::InflictDamage>()
+		.with_handler::<on_player_hit::InflictDamage>()
 		.with::<on_player_hit::SendPacket>()
 		// On player respawn
 		.with::<on_player_respawn::ResetKeyState>()

--- a/server/src/systems/mod.rs
+++ b/server/src/systems/mod.rs
@@ -13,6 +13,7 @@ pub mod handlers;
 pub mod limiting;
 pub mod missile;
 pub mod notify;
+pub mod powerups;
 pub mod specials;
 pub mod spectate;
 pub mod upgrades;

--- a/server/src/systems/position_update.rs
+++ b/server/src/systems/position_update.rs
@@ -134,7 +134,7 @@ impl PositionUpdate {
 					unimplemented!();
 				}
 
-				if powerups.inferno {
+				if powerups.inferno() {
 					max_speed *= info.inferno_factor;
 				}
 
@@ -196,8 +196,8 @@ impl PositionUpdate {
 
 					let ups = ServerUpgrades {
 						speed: upgrades.speed,
-						shield: powerups.shield,
-						inferno: powerups.inferno,
+						shield: powerups.shield(),
+						inferno: powerups.inferno(),
 					};
 
 					let packet = PlayerUpdate {
@@ -251,8 +251,8 @@ impl PositionUpdate {
 
 					let ups = ServerUpgrades {
 						speed: upgrades.speed,
-						shield: powerups.shield,
-						inferno: powerups.inferno,
+						shield: powerups.shield(),
+						inferno: powerups.inferno(),
 					};
 
 					let packet = PlayerUpdate {

--- a/server/src/systems/powerups/check_expired.rs
+++ b/server/src/systems/powerups/check_expired.rs
@@ -1,0 +1,66 @@
+use specs::*;
+
+use SystemInfo;
+
+use types::systemdata::IsAlive;
+use types::Powerups;
+
+use component::channel::OnPowerupExpired;
+use component::event::PowerupExpired;
+use component::time::ThisFrame;
+
+#[derive(Default)]
+pub struct CheckExpired;
+
+#[derive(SystemData)]
+pub struct CheckExpiredData<'a> {
+	pub entities: Entities<'a>,
+	pub powerups: WriteStorage<'a, Powerups>,
+	pub channel: Write<'a, OnPowerupExpired>,
+	pub is_alive: IsAlive<'a>,
+	pub this_frame: Read<'a, ThisFrame>,
+}
+
+impl<'a> System<'a> for CheckExpired {
+	type SystemData = CheckExpiredData<'a>;
+
+	fn run(&mut self, data: Self::SystemData) {
+		let Self::SystemData {
+			entities,
+			mut powerups,
+			mut channel,
+			is_alive,
+			this_frame,
+		} = data;
+
+		let events = (&*entities, &mut powerups, is_alive.mask())
+			.join()
+			.filter(|(_, powerup, ..)| powerup.details.is_some())
+			.filter(|(_, powerup, ..)| powerup.details.unwrap().end_time > this_frame.0)
+			.map(|(ent, powerup, ..)| {
+				let inner = powerup.details.unwrap();
+				powerup.details = None;
+
+				PowerupExpired {
+					player: ent,
+					ty: inner.ty,
+				}
+			});
+
+		for evt in events {
+			channel.single_write(evt);
+		}
+	}
+}
+
+impl SystemInfo for CheckExpired {
+	type Dependencies = ();
+
+	fn name() -> &'static str {
+		concat!(module_path!(), "::", line!())
+	}
+
+	fn new() -> Self {
+		Self::default()
+	}
+}

--- a/server/src/systems/powerups/mod.rs
+++ b/server/src/systems/powerups/mod.rs
@@ -1,0 +1,7 @@
+mod check_expired;
+
+mod register;
+
+pub use self::check_expired::CheckExpired;
+
+pub use self::register::register;

--- a/server/src/systems/powerups/register.rs
+++ b/server/src/systems/powerups/register.rs
@@ -1,0 +1,6 @@
+use super::*;
+use dispatch::Builder;
+
+pub fn register<'a, 'b>(builder: Builder<'a, 'b>) -> Builder<'a, 'b> {
+	builder.with::<CheckExpired>()
+}

--- a/server/src/systems/register.rs
+++ b/server/src/systems/register.rs
@@ -28,4 +28,6 @@ pub fn register<'a, 'b>(disp: Builder<'a, 'b>) -> Builder<'a, 'b> {
 		.with_registrar(upgrades::register)
 		// Admin/Debug Commands
 		.with_registrar(admin::register)
+		// Powerups
+		.with_registrar(powerups::register)
 }

--- a/server/src/types/config.rs
+++ b/server/src/types/config.rs
@@ -401,7 +401,7 @@ impl Default for Config {
 			planes: Default::default(),
 			mobs: Default::default(),
 			upgrades: Default::default(),
-			admin_enabled: false,
+			admin_enabled: true,
 			spawn_shield_duration: Duration::from_secs(2),
 			shield_duration: Duration::from_secs(10),
 			inferno_duration: Duration::from_secs(10),

--- a/server/src/types/config.rs
+++ b/server/src/types/config.rs
@@ -73,12 +73,15 @@ pub struct UpgradeInfos {
 	pub defense: UpgradeInfo,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct Config {
 	pub planes: PlaneInfos,
 	pub mobs: MobInfos,
 	pub upgrades: UpgradeInfos,
 	pub admin_enabled: bool,
+	pub spawn_shield_duration: Duration,
+	pub shield_duration: Duration,
+	pub inferno_duration: Duration,
 }
 
 impl Index<Plane> for PlaneInfos {
@@ -388,6 +391,20 @@ impl Default for UpgradeInfos {
 				cost: [N0, N1, N1, N1, N1, N1],
 				factor: [1.0, 1.05, 1.1, 1.15, 1.2, 1.25],
 			},
+		}
+	}
+}
+
+impl Default for Config {
+	fn default() -> Self {
+		Self {
+			planes: Default::default(),
+			mobs: Default::default(),
+			upgrades: Default::default(),
+			admin_enabled: false,
+			spawn_shield_duration: Duration::from_secs(2),
+			shield_duration: Duration::from_secs(10),
+			inferno_duration: Duration::from_secs(10),
 		}
 	}
 }

--- a/server/src/types/powerups.rs
+++ b/server/src/types/powerups.rs
@@ -1,7 +1,30 @@
 use specs::*;
 
+use protocol::PowerupType;
+
+use std::time::Instant;
+
+#[derive(Copy, Clone, Debug)]
+pub struct PowerupDetails {
+	pub ty: PowerupType,
+	pub end_time: Instant,
+}
+
 #[derive(Default, Clone, Copy, Debug, Component)]
 pub struct Powerups {
-	pub inferno: bool,
-	pub shield: bool,
+	pub details: Option<PowerupDetails>,
+}
+
+impl Powerups {
+	pub fn shield(&self) -> bool {
+		self.details
+			.map(|details| details.ty == PowerupType::Shield)
+			.unwrap_or(false)
+	}
+
+	pub fn inferno(&self) -> bool {
+		self.details
+			.map(|details| details.ty == PowerupType::Inferno)
+			.unwrap_or(false)
+	}
 }

--- a/server/src/utils/event_handler.rs
+++ b/server/src/utils/event_handler.rs
@@ -21,7 +21,7 @@ pub trait EventHandler<'a>: EventHandlerTypeProvider + Send {
 	fn on_event(&mut self, evt: &Self::Event, data: &mut Self::SystemData);
 }
 
-pub struct EventHandlerWrapper<T>
+pub(crate) struct EventHandlerWrapper<T>
 where
 	T: EventHandlerTypeProvider,
 {


### PR DESCRIPTION
This adds support to the engine for shields. It will give joining players shields and adds a command to give a shield to any player, but it doesn't add any code for spawning shield powerups anywhere. It also doesn't add support for respawning players to have shields.

One other note: This bundles a fix for a serialization error in minimap lowres positions.