### PR TITLE
Fix dependencies of player killed handlers (fixes #20)

### DIFF
--- a/server/src/systems/handlers/game/on_player_hit/mod.rs
+++ b/server/src/systems/handlers/game/on_player_hit/mod.rs
@@ -3,3 +3,5 @@ mod send_packet;
 
 pub use self::inflict_damage::InflictDamage;
 pub use self::send_packet::SendPacket;
+
+pub type AllPlayerHitSystems = (InflictDamage, SendPacket);

--- a/server/src/systems/handlers/game/on_player_killed/display_message.rs
+++ b/server/src/systems/handlers/game/on_player_killed/display_message.rs
@@ -5,7 +5,7 @@ use types::*;
 
 use consts::timer::SCORE_BOARD;
 use dispatch::SystemInfo;
-use systems;
+use systems::handlers::game::on_player_hit::AllPlayerHitSystems;
 
 use component::channel::*;
 use component::event::TimerEvent;
@@ -65,7 +65,7 @@ impl<'a> System<'a> for DisplayMessage {
 }
 
 impl SystemInfo for DisplayMessage {
-	type Dependencies = (systems::missile::MissileHit);
+	type Dependencies = (AllPlayerHitSystems);
 
 	fn name() -> &'static str {
 		concat!(module_path!(), "::", line!())

--- a/server/src/systems/handlers/game/on_player_killed/set_respawn_timer.rs
+++ b/server/src/systems/handlers/game/on_player_killed/set_respawn_timer.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use component::channel::*;
 use component::event::*;
 use consts::timer::RESPAWN_TIME;
+use systems::handlers::game::on_player_hit::AllPlayerHitSystems;
 use systems::missile::MissileHit;
 
 pub struct SetRespawnTimer {
@@ -46,7 +47,7 @@ impl<'a> System<'a> for SetRespawnTimer {
 }
 
 impl SystemInfo for SetRespawnTimer {
-	type Dependencies = MissileHit;
+	type Dependencies = (MissileHit, AllPlayerHitSystems);
 
 	fn name() -> &'static str {
 		concat!(module_path!(), "::", line!())


### PR DESCRIPTION
The bug was causd by the player killed event queue message being
scheduled between the system that sent out the ScoreUpdate packet
and the system that sent out the PlayerKilled packet.