### PR TITLE
#27: Drop flag on respawn

### DIFF
--- a/ctf/src/systems/drop_on_respawn.rs
+++ b/ctf/src/systems/drop_on_respawn.rs
@@ -1,0 +1,73 @@
+use specs::*;
+
+use component::*;
+
+use server::component::channel::*;
+use server::*;
+
+pub struct DropOnRespawn {
+    pub reader: Option<OnCommandReader>,
+}
+
+#[derive(SystemData)]
+pub struct DropOnRespawnData<'a> {
+    pub channel: Write<'a, OnFlag>,
+    pub commands: Read<'a, OnCommand>,
+    pub conns: Read<'a, Connections>,
+    pub entities: Entities<'a>,
+
+    pub carrier: WriteStorage<'a, FlagCarrier>,
+
+    pub isflag: ReadStorage<'a, IsFlag>,
+}
+
+impl<'a> System<'a> for DropOnRespawn {
+    type SystemData = DropOnRespawnData<'a>;
+
+    fn setup(&mut self, res: &mut Resources) {
+        Self::SystemData::setup(res);
+
+        self.reader = Some(res.fetch_mut::<OnCommand>().register_reader());
+    }
+
+    fn run(&mut self, mut data: Self::SystemData) {
+        let mut channel = data.channel;
+
+        for (id, packet) in data.commands.read(self.reader.as_mut().unwrap()) {
+            let player = match data.conns.associated_player(*id) {
+                Some(p) => p,
+                None => continue,
+            };
+
+            if packet.com != "respawn" {
+                continue;
+            }
+
+            (&*data.entities, &mut data.carrier, &data.isflag)
+                .join()
+                .filter(|(_, carrier, _)| carrier.0.is_some())
+                .filter(|(_, carrier, _)| carrier.0.unwrap() == player)
+                .for_each(|(ent, carrier, _)| {
+                    channel.single_write(FlagEvent {
+                        ty: FlagEventType::Drop,
+                        player: Some(player),
+                        flag: ent,
+                    });
+
+                    carrier.0 = None;
+                });
+        }
+    }
+}
+
+impl SystemInfo for DropOnRespawn {
+    type Dependencies = ();
+
+    fn name() -> &'static str {
+        concat!(module_path!(), "::", line!())
+    }
+
+    fn new() -> Self {
+        Self { reader: None }
+    }
+}

--- a/ctf/src/systems/mod.rs
+++ b/ctf/src/systems/mod.rs
@@ -1,5 +1,6 @@
 mod drop;
 mod drop_on_death;
+mod drop_on_respawn;
 mod drop_on_spec;
 mod flagspeed;
 mod pickupflag;
@@ -19,6 +20,7 @@ pub use self::register::register;
 
 pub use self::drop::DropSystem;
 pub use self::drop_on_death::DropOnDeath;
+pub use self::drop_on_respawn::DropOnRespawn;
 pub use self::drop_on_spec::DropOnSpec;
 pub use self::flagspeed::FlagSpeedSystem;
 pub use self::pickupflag::PickupFlagSystem;

--- a/ctf/src/systems/register.rs
+++ b/ctf/src/systems/register.rs
@@ -42,6 +42,7 @@ pub fn register<'a, 'b>(world: &mut World, disp: Builder<'a, 'b>) -> Builder<'a,
 
 	disp
 		.with::<DropOnSpec>()
+		.with::<DropOnRespawn>()
 		.with::<DropOnDeath>()
 		.with::<ScoreDetailed>()
 		// On Leave Events


### PR DESCRIPTION
More or less a shameless copy of `drop_on_spec.rs`, but it works! That code contains this piece of code which I'm not totally sure what it does, but removing it is necessary for the code to work with respawning instead of spec.

```rust
let target: i32 = match packet.data.parse() {
    Ok(v) => v,
    Err(_) => continue,
};

match target {
    -3...-1 => (),
    _ => continue,
}
```