### PR TITLE
#23. Make sure players have full health before allowing respawn

### DIFF
--- a/server/src/handlers/command.rs
+++ b/server/src/handlers/command.rs
@@ -25,6 +25,7 @@ pub struct CommandHandlerData<'a> {
 	planes: WriteStorage<'a, Plane>,
 	flags: WriteStorage<'a, FlagCode>,
 	isspec: WriteStorage<'a, IsSpectating>,
+	health: ReadStorage<'a, Health>,
 }
 
 impl CommandHandler {
@@ -72,6 +73,16 @@ impl<'a> System<'a> for CommandHandler {
 					Ok(n) => n,
 					_ => continue,
 				};
+
+				// Make sure player health is full before allowing respawn
+				match data.health.get(player) {
+					Some(&health) => {
+						if health < Health::new(1.0) { // TODO: Actual number is slightly lower than 1.0?
+							continue;
+						}
+					},
+					_ => continue,
+				}
 
 				*data.planes.get_mut(player).unwrap() = ty;
 				data.isspec.remove(player);


### PR DESCRIPTION
Players can still immediately respawn after reaching full health, i.e. #24 still does not work. Also, I was under the impression that you needed full health before respawning, and not 90-95%.