### PR TITLE
Fix game flag handling bugs

### DIFF
--- a/ctf/src/systems/on_flag/mod.rs
+++ b/ctf/src/systems/on_flag/mod.rs
@@ -11,3 +11,12 @@ pub use self::send_flag_message::SendFlagMessageSystem as SendFlagMessage;
 pub use self::update_captures::UpdateCaptures;
 pub use self::update_lastdrop::UpdateLastDrop;
 pub use self::update_score::UpdateScore;
+
+pub type AllFlagSystems = (
+	CheckWin,
+	PickupMessage,
+	SendFlagMessage,
+	UpdateCaptures,
+	UpdateLastDrop,
+	UpdateScore,
+);

--- a/ctf/src/systems/on_flag/send_flag_message.rs
+++ b/ctf/src/systems/on_flag/send_flag_message.rs
@@ -57,24 +57,24 @@ impl<'a> System<'a> for SendFlagMessageSystem {
 					data.scores.redteam += 1;
 					other = data.flags.red;
 				} else {
+					// Other flags are not implemented for CTF
+					// if you are using this code as a base,
+					// support for other flags will need to be
+					// implemented.
 					unimplemented!();
 				}
 
-				let pos;
 				if data.carrier.get(other).unwrap().0.is_none() {
-					pos = *data.pos.get(other).unwrap();
-				} else {
-					pos = Position::default();
+					let pos = *data.pos.get(other).unwrap();
+					data.conns.send_to_all(GameFlag {
+						ty,
+						flag: Flag(*data.team.get(other).unwrap()),
+						pos: pos,
+						id: None,
+						blueteam: data.scores.blueteam,
+						redteam: data.scores.redteam,
+					});
 				}
-
-				data.conns.send_to_all(GameFlag {
-					ty,
-					flag: Flag(*data.team.get(other).unwrap()),
-					pos: pos,
-					id: None,
-					blueteam: data.scores.blueteam,
-					redteam: data.scores.redteam,
-				});
 			}
 
 			data.conns.send_to_all(GameFlag {

--- a/ctf/src/systems/on_flag/send_flag_message.rs
+++ b/ctf/src/systems/on_flag/send_flag_message.rs
@@ -64,16 +64,29 @@ impl<'a> System<'a> for SendFlagMessageSystem {
 					unimplemented!();
 				}
 
+				let flag = Flag(*data.team.get(other).unwrap());
+
 				if data.carrier.get(other).unwrap().0.is_none() {
 					let pos = *data.pos.get(other).unwrap();
 					data.conns.send_to_all(GameFlag {
 						ty,
-						flag: Flag(*data.team.get(other).unwrap()),
+						flag,
 						pos: pos,
 						id: None,
 						blueteam: data.scores.blueteam,
 						redteam: data.scores.redteam,
 					});
+				} else {
+					let carrier = data.carrier.get(other).unwrap().0.map(|x| x.into());
+
+					data.conns.send_to_all(GameFlag {
+						ty: FlagUpdateType::Carrier,
+						flag,
+						pos: Position::default(),
+						id: carrier,
+						blueteam: data.scores.blueteam,
+						redteam: data.scores.redteam,
+					})
 				}
 			}
 

--- a/ctf/src/systems/on_game_win/mod.rs
+++ b/ctf/src/systems/on_game_win/mod.rs
@@ -5,6 +5,7 @@ mod set_game_active;
 mod setup_game_start;
 mod setup_messages;
 mod setup_reteam;
+mod reset_flags;
 
 pub use self::award_bounty::AwardBounty;
 pub use self::change_config::ChangeConfig;
@@ -13,3 +14,4 @@ pub use self::set_game_active::SetGameActive;
 pub use self::setup_game_start::SetupGameStart;
 pub use self::setup_messages::SetupMessages;
 pub use self::setup_reteam::SetupReteam;
+pub use self::reset_flags::ResetFlags;

--- a/ctf/src/systems/on_game_win/mod.rs
+++ b/ctf/src/systems/on_game_win/mod.rs
@@ -1,17 +1,17 @@
 mod award_bounty;
 mod change_config;
 mod display_win;
+mod reset_flags;
 mod set_game_active;
 mod setup_game_start;
 mod setup_messages;
 mod setup_reteam;
-mod reset_flags;
 
 pub use self::award_bounty::AwardBounty;
 pub use self::change_config::ChangeConfig;
 pub use self::display_win::DisplayWin;
+pub use self::reset_flags::ResetFlags;
 pub use self::set_game_active::SetGameActive;
 pub use self::setup_game_start::SetupGameStart;
 pub use self::setup_messages::SetupMessages;
 pub use self::setup_reteam::SetupReteam;
-pub use self::reset_flags::ResetFlags;

--- a/ctf/src/systems/on_game_win/reset_flags.rs
+++ b/ctf/src/systems/on_game_win/reset_flags.rs
@@ -1,0 +1,55 @@
+
+use specs::*;
+
+use component::*;
+
+use server::SystemInfo;
+use server::utils::event_handler::{EventHandler, EventHandlerTypeProvider};
+
+use {RED_TEAM, BLUE_TEAM};
+
+#[derive(Default)]
+pub struct ResetFlags;
+
+#[derive(SystemData)]
+pub struct ResetFlagsData<'a> {
+	channel: Write<'a, OnFlag>,
+	flags: ReadExpect<'a, Flags>,
+}
+
+impl EventHandlerTypeProvider for ResetFlags {
+	type Event = GameWinEvent;
+}
+
+impl<'a> EventHandler<'a> for ResetFlags {
+	type SystemData = ResetFlagsData<'a>;
+
+	fn on_event(&mut self, evt: &GameWinEvent, data: &mut Self::SystemData) {
+		let winner = evt.winning_team;
+		let flag = if winner == RED_TEAM { 
+			data.flags.blue
+		} else if winner == BLUE_TEAM { 
+			data.flags.red
+		 } else { 
+			 unimplemented!() 
+			 };
+
+		data.channel.single_write(FlagEvent {
+			flag,
+			player: None,
+			ty: FlagEventType::Return
+		});
+	}
+}
+
+impl SystemInfo for ResetFlags {
+	type Dependencies = super::SetGameActive;
+
+	fn name() -> &'static str {
+		concat!(module_path!(), "::", line!())
+	}
+
+	fn new() -> Self {
+		Self::default()
+	}
+}

--- a/ctf/src/systems/on_game_win/reset_flags.rs
+++ b/ctf/src/systems/on_game_win/reset_flags.rs
@@ -1,12 +1,11 @@
-
 use specs::*;
 
 use component::*;
 
-use server::SystemInfo;
 use server::utils::event_handler::{EventHandler, EventHandlerTypeProvider};
+use server::SystemInfo;
 
-use {RED_TEAM, BLUE_TEAM};
+use {BLUE_TEAM, RED_TEAM};
 
 #[derive(Default)]
 pub struct ResetFlags;
@@ -26,18 +25,18 @@ impl<'a> EventHandler<'a> for ResetFlags {
 
 	fn on_event(&mut self, evt: &GameWinEvent, data: &mut Self::SystemData) {
 		let winner = evt.winning_team;
-		let flag = if winner == RED_TEAM { 
+		let flag = if winner == RED_TEAM {
 			data.flags.blue
-		} else if winner == BLUE_TEAM { 
+		} else if winner == BLUE_TEAM {
 			data.flags.red
-		 } else { 
-			 unimplemented!() 
-			 };
+		} else {
+			unimplemented!()
+		};
 
 		data.channel.single_write(FlagEvent {
 			flag,
 			player: None,
-			ty: FlagEventType::Return
+			ty: FlagEventType::Return,
 		});
 	}
 }

--- a/ctf/src/systems/on_game_win/reset_flags.rs
+++ b/ctf/src/systems/on_game_win/reset_flags.rs
@@ -1,6 +1,7 @@
 use specs::*;
 
 use component::*;
+use systems::on_flag::AllFlagSystems;
 
 use server::utils::event_handler::{EventHandler, EventHandlerTypeProvider};
 use server::SystemInfo;
@@ -42,7 +43,7 @@ impl<'a> EventHandler<'a> for ResetFlags {
 }
 
 impl SystemInfo for ResetFlags {
-	type Dependencies = super::SetGameActive;
+	type Dependencies = (super::SetGameActive, AllFlagSystems);
 
 	fn name() -> &'static str {
 		concat!(module_path!(), "::", line!())

--- a/ctf/src/systems/register.rs
+++ b/ctf/src/systems/register.rs
@@ -73,6 +73,7 @@ pub fn register<'a, 'b>(world: &mut World, disp: Builder<'a, 'b>) -> Builder<'a,
 		.with::<on_game_win::DisplayWin>()
 		.with::<on_game_win::SetGameActive>()
 		.with::<on_game_win::AwardBounty>()
+		.with_handler::<on_game_win::ResetFlags>()
 		// Timer events
 		.with::<timer::RestoreConfig>()
 		.with::<timer::GameStart>()

--- a/protocol-common/src/enums/flag_update_type.rs
+++ b/protocol-common/src/enums/flag_update_type.rs
@@ -12,8 +12,7 @@ impl_try_from_enum! {
 	///
 	/// Implementors Note: This had a `TODO: rev-eng`
 	/// comment on it but it doesn't seem to be missing
-	/// any values. It might be worth doing some more
-	/// looking to see if anything turns up here.
+	/// any values.
 	#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 	#[cfg_attr(feature = "specs", derive(Component))]
 	#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -42,7 +42,6 @@ mod server;
 mod status;
 mod timeloop;
 mod timers;
-mod utils;
 
 pub use protocol_common as protocol;
 
@@ -50,6 +49,7 @@ pub mod component;
 pub mod consts;
 pub mod systems;
 pub mod types;
+pub mod utils;
 
 use protocol as airmash_protocol;
 


### PR DESCRIPTION
This pr fixes the following bugs:
- Players can hold onto flags into the intermission (roughly #28)
- Flag teleports to the origin when the other team caps if a player is carrying (issue #21)
