### PR TITLE
Fix #16: Determine missile ranges for all planes

### DIFF
--- a/server/src/types/config.rs
+++ b/server/src/types/config.rs
@@ -254,8 +254,6 @@ impl Default for MobInfos {
 			  damage that would be done to a goliath.
 			- This will then be multiplied by a factor
 			  specific to each plane type
-			- Missile lifetime should be replaced with
-			  a missile distance modifier
 		*/
 
 		map.insert(
@@ -268,7 +266,7 @@ impl Default for MobInfos {
 					base_speed: Speed::new(4.05),
 					speed_factor: 0.3,
 					damage: Health::new(0.4),
-					distance: Distance::new(1000.0),
+					distance: Distance::new(1104.0),
 				}),
 			},
 		);
@@ -283,7 +281,7 @@ impl Default for MobInfos {
 					base_speed: Speed::new(2.1),
 					speed_factor: 0.3,
 					damage: Health::new(1.2),
-					distance: Distance::new(1000.0),
+					distance: Distance::new(1076.0),
 				}),
 			},
 		);
@@ -298,7 +296,7 @@ impl Default for MobInfos {
 					base_speed: Speed::new(5.7),
 					speed_factor: 0.3,
 					damage: Health::new(0.2),
-					distance: Distance::new(1000.0),
+					distance: Distance::new(1161.0),
 				}),
 			},
 		);
@@ -313,7 +311,7 @@ impl Default for MobInfos {
 					base_speed: Speed::new(3.5),
 					speed_factor: 0.3,
 					damage: Health::new(0.4),
-					distance: Distance::new(1000.0),
+					distance: Distance::new(997.0),
 				}),
 			},
 		);
@@ -328,7 +326,7 @@ impl Default for MobInfos {
 					base_speed: Speed::new(3.5),
 					speed_factor: 0.3,
 					damage: Health::new(0.3),
-					distance: Distance::new(500.0),
+					distance: Distance::new(581.0),
 				}),
 			},
 		);
@@ -343,7 +341,7 @@ impl Default for MobInfos {
 					base_speed: Speed::new(2.8),
 					speed_factor: 0.3,
 					damage: Health::new(0.45),
-					distance: Distance::new(1000.0),
+					distance: Distance::new(819.0),
 				}),
 			},
 		);


### PR DESCRIPTION
Method: paste this into the console and fire a bunch of missiles. `mobDestroyed` overestimates distances, so `mobDespawned` is used instead.
```js
let missilePositions = {}
let distances = {}
let dist = (x1, y1, x2, y2) => Math.sqrt((x1 - x2) ** 2 + (y1 - y2) ** 2);
let average = (arr) => arr.reduce((a, b) => a + b, 0) / arr.length;
SWAM.on("mobAdded", function (missile) {
  missilePositions[missile.id] = [missile.posX, missile.posY]
});
SWAM.on("mobDespawned", function (mob) {
  let missile = Mobs.get(mob.id);
  let [posX, posY] = missilePositions[missile.id]
  distances[missile.type] = distances[missile.type] || [];
  if (missile.pos) {
    distances[missile.type].push(dist(posX, posY, missile.pos.x, missile.pos.y))
    console.log(`Average for missile type ${missile.type}: ${average(distances[missile.type])}`);
  }
});
```