### PR TITLE
Fix Issue #30 spawn shield incorrect

### DIFF
--- a/protocol-common/src/packets/server/player_powerup.rs
+++ b/protocol-common/src/packets/server/player_powerup.rs
@@ -1,11 +1,12 @@
 use enums::PowerupType;
 
-/// A player picked up a powerup
+/// The current player picked up a powerup.
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PlayerPowerup {
 	#[cfg_attr(feature = "serde", serde(rename = "type"))]
 	pub ty: PowerupType,
 	// Maybe make this a Duration?
+	/// Lifetime of the powerup, in milliseconds.
 	pub duration: u32,
 }

--- a/server/src/systems/handlers/game/on_join/send_player_powerup.rs
+++ b/server/src/systems/handlers/game/on_join/send_player_powerup.rs
@@ -44,7 +44,7 @@ impl<'a> EventHandler<'a> for SendPlayerPowerup {
 		let duration = data.config.spawn_shield_duration.as_secs() * 1000
 			+ data.config.spawn_shield_duration.subsec_millis() as u64;
 
-		data.conns.send_to_visible(
+		data.conns.send_to_player(
 			evt.id,
 			PlayerPowerup {
 				duration: duration as u32,


### PR DESCRIPTION
The issue was caused by sending `PlayerPowerup` to all players. This fixes that and changes the documentation for `PlayerPowerup` to clarify that it applies to the player that receives it.