### PR TITLE
Fix #89 - jitter due to to_clock() operator precedence bug

### DIFF
--- a/server/src/types/components.rs
+++ b/server/src/types/components.rs
@@ -23,7 +23,8 @@ pub trait ToClock {
 }
 
 impl ToClock for Duration {
+	// Unit is hundredths of a millisecond. (1/1e5)
 	fn to_clock(&self) -> u32 {
-		(self.as_secs() * 1_000_000) as u32 + self.subsec_micros() / 10
+		((self.as_secs() * 1_000_000) as u32 + self.subsec_micros()) / 10
 	}
 }


### PR DESCRIPTION
expr was being parsed as (secs*1e6) + (usecs/10)
expr should produce duration measured in hundreds of a millisecond, so:

	((secs*1e6)+usecs)/10

See js/Network.js dispatchIncomingMessage - value is divided by 100 then
compared against performance.now(), which is measured in milliseconds.