### PR TITLE
Rayon taming & blast radius reduction

### DIFF
--- a/ffa/src/main.rs
+++ b/ffa/src/main.rs
@@ -45,6 +45,13 @@ fn init_sentry() -> Option<sentry::internals::ClientInitGuard> {
     }
 }
 
+fn set_default_var(name: &str, value: &str)
+{
+    if None == env::var_os(name) {
+        env::set_var(name, value);
+    }
+}
+
 fn main() {
     let matches = clap::App::new("airmash-server-ffa")
         .version(env!("CARGO_PKG_VERSION"))
@@ -53,8 +60,9 @@ fn main() {
         .args_from_usage("-c, --config=[FILE] 'Provides an alternate config file'")
         .get_matches();
 
-    env::set_var("RUST_BACKTRACE", "1");
-    env::set_var("RUST_LOG", "info");
+    set_default_var("RUST_BACKTRACE", "1");
+    set_default_var("RUST_LOG", "info");
+    set_default_var("RAYON_NUM_THREADS", "1");
     let _guard = init_sentry();
 
     let mut config = AirmashServerConfig::new("0.0.0.0:3501", EmptyGameMode).with_engine();

--- a/server/src/systems/collision/missile.rs
+++ b/server/src/systems/collision/missile.rs
@@ -52,7 +52,7 @@ impl<'a> System<'a> for MissileTerrainCollisionSystem {
 			&data.team,
 			&data.flag,
 		)
-			.par_join()
+			.join()
 			.map(|(ent, pos, mob, team, _)| {
 				let it = COLLIDERS[mob].iter().map(|(offset, rad)| HitCircle {
 					pos: *pos + *offset,

--- a/server/src/systems/collision/plane.rs
+++ b/server/src/systems/collision/plane.rs
@@ -54,7 +54,7 @@ impl<'a> System<'a> for PlaneCollisionSystem {
 			&data.planes,
 			&data.teams,
 		)
-			.par_join()
+			.join()
 			.map(|(ent, pos, rot, plane, team)| {
 				let it = (*PLANE_HIT_CIRCLES)[plane].iter().map(|hc| {
 					let offset = hc.offset.rotate(*rot);


### PR DESCRIPTION
Per previous conversations, Rayon is extremely aggressive and has perhaps a worst-case busywaiting behaviour given the Airmash workload. On a 16 thread machine it's possible to observe it consuming 8 full cores, doing nothing more than calling `sched_yield()` in a loop, with most of the CPU time being burned in the kernel scheduler.

These changes help bring the server down to something more reasonable - 10% of one core given around 30 connections.