### PR TITLE
Fix crash when a player picks up a powerup then immediately leaves

### DIFF
--- a/server/src/systems/handlers/game/on_player_powerup/set_powerup_lifetime.rs
+++ b/server/src/systems/handlers/game/on_player_powerup/set_powerup_lifetime.rs
@@ -13,6 +13,7 @@ pub struct SetPowerupLifetime;
 pub struct SetPowerupLifetimeData<'a> {
 	powerups: WriteStorage<'a, Powerups>,
 	this_frame: Read<'a, ThisFrame>,
+	entities: Entities<'a>,
 }
 
 impl EventHandlerTypeProvider for SetPowerupLifetime {
@@ -23,6 +24,10 @@ impl<'a> EventHandler<'a> for SetPowerupLifetime {
 	type SystemData = SetPowerupLifetimeData<'a>;
 
 	fn on_event(&mut self, evt: &PlayerPowerup, data: &mut Self::SystemData) {
+		if !data.entities.is_alive(evt.player) {
+			return;
+		}
+
 		data.powerups
 			.insert(
 				evt.player,


### PR DESCRIPTION
Addresses the newest crash in #85 