### PR TITLE
Fix another crash (#85)

### DIFF
--- a/server/src/systems/handlers/game/on_player_powerup/trigger_update.rs
+++ b/server/src/systems/handlers/game/on_player_powerup/trigger_update.rs
@@ -13,6 +13,7 @@ pub struct TriggerUpdate;
 #[derive(SystemData)]
 pub struct TriggerUpdateData<'a> {
 	force_update: WriteStorage<'a, ForcePlayerUpdate>,
+	entities: Entities<'a>,
 }
 
 impl EventHandlerTypeProvider for TriggerUpdate {
@@ -23,6 +24,10 @@ impl<'a> EventHandler<'a> for TriggerUpdate {
 	type SystemData = TriggerUpdateData<'a>;
 
 	fn on_event(&mut self, evt: &PlayerPowerup, data: &mut Self::SystemData) {
+		if !data.entities.is_alive(evt.player) {
+			return;
+		}
+
 		data.force_update
 			.insert(evt.player, ForcePlayerUpdate)
 			.unwrap();


### PR DESCRIPTION

Fix a crash similar to f315fcd14ca6c6940ebe286cf1b813b19be69418
<details><summary>Backtrace:</summary>
<p>

```
**thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: WrongGeneration(WrongGeneration { action: "insert component for entity", actual_gen: Generation(-15), entity: Entity(41
0, Generation(15)) })', src/libcore/result.rs:1084:5
stack backtrace:
   0: backtrace::backtrace::libunwind::trace
             at ./cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.29/src/backtrace/libunwind.rs:88
   1: backtrace::backtrace::trace_unsynchronized
             at ./cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.29/src/backtrace/mod.rs:66
   2: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:47
   3: std::sys_common::backtrace::print
             at src/libstd/sys_common/backtrace.rs:36
   4: std::panicking::default_hook::{{closure}}
             at src/libstd/panicking.rs:200
   5: std::panicking::default_hook
             at src/libstd/panicking.rs:214
   6: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:477
   7: std::panicking::continue_panic_fmt
             at src/libstd/panicking.rs:384
   8: rust_begin_unwind
             at src/libstd/panicking.rs:311
   9: core::panicking::panic_fmt
             at src/libcore/panicking.rs:85
  10: core::result::unwrap_failed
             at src/libcore/result.rs:1084
  11: core::result::Result<T,E>::unwrap
             at ./rustc/04b88a9eba8abbac87eddcb2998beea09589c2c9/src/libcore/result.rs:852
  12: <airmash_server::systems::handlers::game::on_player_powerup::trigger_update::TriggerUpdate as airmash_server::utils::event_handler::EventHandler>::on_event
             at server/src/systems/handlers/game/on_player_powerup/trigger_update.rs:26
  13: <airmash_server::utils::event_handler::EventHandlerWrapper<T> as shred::system::System>::run
             at server/src/utils/event_handler.rs:81
  14: <airmash_server::dispatch::syswrapper::SystemWrapper<T> as shred::system::System>::run
             at server/src/dispatch/syswrapper.rs:50
  15: <T as shred::system::RunNow>::run_now**
```
</p>
</details>
