### PR TITLE
Add config option to disallow going into spec while moving

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -224,6 +224,7 @@
     }
   },
   "admin_enabled": true,
+  "allow_spectate_while_moving": true,
   "spawn_shield_duration": {
     "secs": 2,
     "nanos": 0

--- a/config/no-moving-spectate.json
+++ b/config/no-moving-spectate.json
@@ -1,0 +1,3 @@
+{
+  "allow_spectate_while_moving": false
+}

--- a/ffa/src/main.rs
+++ b/ffa/src/main.rs
@@ -86,7 +86,10 @@ fn main() {
 
         let mut de = serde_json::Deserializer::new(serde_json::de::IoRead::new(file));
 
-        let mut serverconfig = Config::default();
+        let mut serverconfig = Config {
+            allow_spectate_while_moving: false,
+            ..Config::default()
+        };
         serverconfig.deserialize_over(&mut de).unwrap();
 
         config.world.add_resource(serverconfig);

--- a/server/src/bin/dump-config.rs
+++ b/server/src/bin/dump-config.rs
@@ -1,16 +1,11 @@
 use std::error::Error;
-use std::fs::File;
-use std::io::Write;
-
 use airmash_server::types::Config;
 
 fn main() -> Result<(), Box<dyn Error>> {
 	let config = Config::default();
 	let json = serde_json::to_string_pretty(&config)?;
 
-	let mut file = File::create("default-config.json")?;
-
-	writeln!(file, "{}", json)?;
+	println!("{}", json);
 
 	Ok(())
 }

--- a/server/src/types/config.rs
+++ b/server/src/types/config.rs
@@ -124,6 +124,7 @@ pub struct Config {
 	pub upgrades: UpgradeInfos,
 
 	pub admin_enabled: bool,
+	pub allow_spectate_while_moving: bool,
 	pub spawn_shield_duration: Duration,
 	pub shield_duration: Duration,
 	pub inferno_duration: Duration,
@@ -248,6 +249,7 @@ impl Default for Config {
 			// default feature defined. Ensure admin commands are disabled by
 			// default in release mode, unless explicitly requested.
 			admin_enabled: cfg!(debug_assertions),
+			allow_spectate_while_moving: true,
 			spawn_shield_duration: Duration::from_secs(2),
 			shield_duration: Duration::from_secs(10),
 			inferno_duration: Duration::from_secs(10),


### PR DESCRIPTION
In addition, disable going into spectate while moving by default for FFA