### PR TITLE
Fix status page to actually return the number of players

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,7 @@ dependencies = [
  "futures-util",
  "fxhash",
  "hecs",
+ "httparse",
  "itertools",
  "kdtree",
  "linkme",

--- a/server-next/Cargo.toml
+++ b/server-next/Cargo.toml
@@ -20,6 +20,7 @@ smallvec = "1.6"
 itertools = "0.10"
 slab = "0.4"
 fxhash = "0.2"
+httparse = "1.6.0"
 
 tokio = { version="1.0", features=["rt", "sync", "io-util", "macros", "time", "rt-multi-thread"] }
 tokio-tungstenite = "0.17.1"

--- a/server-next/src/util/escapes.rs
+++ b/server-next/src/util/escapes.rs
@@ -1,0 +1,50 @@
+use std::fmt::Display;
+
+use itertools::Itertools;
+use smallvec::SmallVec;
+
+pub(crate) trait StringEscape {
+  fn escaped(&self) -> AsciiEscapedString;
+}
+
+impl StringEscape for [u8] {
+  fn escaped(&self) -> AsciiEscapedString {
+    AsciiEscapedString(self)
+  }
+}
+
+pub(crate) struct AsciiEscapedString<'a>(&'a [u8]);
+
+impl<'a> Display for AsciiEscapedString<'a> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    let mut bytes = self.0;
+
+    loop {
+      if let Some(len) = bytes
+        .iter()
+        .find_position(|&c| match c {
+          b'"' | b'\'' | b'\\' => false,
+          0x20..=0x7E => true,
+          _ => false,
+        })
+        .map(|x| x.0)
+      {
+        f.write_str(unsafe { std::str::from_utf8_unchecked(&bytes[..len]) })?;
+        bytes = &bytes[len..];
+      }
+
+      let next = match bytes.split_first() {
+        Some((next, rest)) => {
+          bytes = rest;
+          *next
+        }
+        None => break,
+      };
+
+      let temp: SmallVec<[u8; 4]> = std::ascii::escape_default(next).collect();
+      f.write_str(unsafe { std::str::from_utf8_unchecked(&temp) })?;
+    }
+
+    Ok(())
+  }
+}

--- a/server-next/src/util/mod.rs
+++ b/server-next/src/util/mod.rs
@@ -8,6 +8,7 @@ use crate::AirmashGame;
 use nalgebra::vector;
 use std::time::Duration;
 
+pub(crate) mod escapes;
 pub mod spectate;
 
 pub fn convert_time(dur: Duration) -> Time {


### PR DESCRIPTION
Due to some changes in tungstenite or tokio-tungstenite it is no longer possible to return a response from accept_hdr_async that is not either
1. the continuation of the websocket handshake, or
2. an error response.

This causes a problem for airmash servers since the client actually queries the server endpoint and expects a 200 OK response with a json payload if the request is not a websocket request. To work around this, I have manually reimplemented the websocket handshake so that we can return the expected results when a non-websocket request comes in.