### PR TITLE
Actually pass cargo flags instead of literal $CARGO_FLAGS

### DIFF
--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --color always $CARGO_FLAGS
+          args: --color always ${{ env.CARGO_FLAGS }}
   
   format:
     name: check-fmt


### PR DESCRIPTION
As it turns out, this actually gets interpreted as a test filter and so CI doesn't end up running any tests.