### PR TITLE
Make server-estimated ping times more accurate

### DIFF
--- a/server-next/src/component/mod.rs
+++ b/server-next/src/component/mod.rs
@@ -4,7 +4,7 @@ use crate::protocol::PowerupType;
 use airmash_protocol::Vector2;
 use bstr::BString;
 use hecs::Entity;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use uuid::Uuid;
 
 mod keystate;
@@ -73,7 +73,7 @@ def_wrappers! {
   pub type TotalDamage = f32;
 
   /// The current ping of a player.
-  pub type PlayerPing = u16;
+  pub type PlayerPing = Duration;
 
   /// The player that another spectating player is watching.
   #[derive(Default)]

--- a/server-next/src/defaults.rs
+++ b/server-next/src/defaults.rs
@@ -2,8 +2,8 @@
 //! meant to make it easier add new ones for use within the main server.
 //! (External code can add them in EntitySpawn events if it needs to.)
 
-use std::str::FromStr;
 use std::time::Instant;
+use std::{str::FromStr, time::Duration};
 
 use hecs::EntityBuilder;
 use uuid::Uuid;
@@ -56,7 +56,7 @@ pub(crate) fn build_default_player(
     .add(Powerup::default())
     .add(JoinTime(this_frame))
     .add(Spectating::default())
-    .add(PlayerPing(0))
+    .add(PlayerPing(Duration::ZERO))
     .add(TotalDamage(0.0))
     .add(Captures(0));
 

--- a/server-next/src/event/packet.rs
+++ b/server-next/src/event/packet.rs
@@ -1,5 +1,6 @@
 use crate::{network::ConnectionId, protocol::client as c};
 use hecs::Entity;
+use std::time::Instant;
 
 /// A packet has been recieved from a connection that has been associated with
 /// an entity.
@@ -13,6 +14,8 @@ use hecs::Entity;
 pub struct PacketEvent<P> {
   pub conn: ConnectionId,
   pub entity: Entity,
+  // The time at which the packet was received
+  pub time: Instant,
   pub packet: P,
 }
 

--- a/server-next/src/mock.rs
+++ b/server-next/src/mock.rs
@@ -83,7 +83,13 @@ impl MockConnection {
 
     self
       .tx
-      .send((self.conn, InternalEvent::Data(data)))
+      .send((
+        self.conn,
+        InternalEvent::Data {
+          data,
+          time: Instant::now(),
+        },
+      ))
       .expect("Network event channel is closed");
   }
 

--- a/server-next/src/system/ctf.rs
+++ b/server-next/src/system/ctf.rs
@@ -33,7 +33,7 @@ fn respond_to_packet(event: &PacketEvent<ScoreDetailed>, game: &mut AirmashGame)
       kills: kills.0.try_into().unwrap_or(u16::MAX),
       deaths: deaths.0.try_into().unwrap_or(u16::MAX),
       damage: damage.0,
-      ping: ping.0,
+      ping: ping.as_millis().try_into().unwrap_or(u16::MAX),
     });
   }
 

--- a/server-next/src/system/ffa.rs
+++ b/server-next/src/system/ffa.rs
@@ -33,7 +33,7 @@ fn respond_to_packet(event: &PacketEvent<ScoreDetailed>, game: &mut AirmashGame)
       kills: kills.0.try_into().unwrap_or(u16::MAX),
       deaths: deaths.0.try_into().unwrap_or(u16::MAX),
       damage: damage.0,
-      ping: ping.0,
+      ping: ping.as_millis().try_into().unwrap_or(u16::MAX),
     });
   }
 

--- a/server-next/src/system/network.rs
+++ b/server-next/src/system/network.rs
@@ -38,11 +38,9 @@ pub fn process_packets(game: &mut AirmashGame) {
 
     drop(conn_mgr);
 
-    let data = match evt {
-      ConnectionEvent::Opened => {
-        continue;
-      }
-      ConnectionEvent::Data(data) => data,
+    let (data, time) = match evt {
+      ConnectionEvent::Opened => continue,
+      ConnectionEvent::Data { data, time } => (data, time),
       ConnectionEvent::Closed(None) => continue,
       ConnectionEvent::Closed(Some(entity)) => {
         if !game.world.contains(entity) {
@@ -83,61 +81,73 @@ pub fn process_packets(game: &mut AirmashGame) {
       ClientPacket::Horizon(packet) => game.dispatch(PacketEvent {
         entity: assoc.unwrap(),
         conn,
+        time,
         packet,
       }),
       ClientPacket::Ack => game.dispatch(PacketEvent {
         entity: assoc.unwrap(),
         conn,
+        time,
         packet: c::Ack,
       }),
       ClientPacket::Pong(packet) => game.dispatch(PacketEvent {
         entity: assoc.unwrap(),
         conn,
+        time,
         packet,
       }),
       ClientPacket::Key(packet) => game.dispatch(PacketEvent {
         entity: assoc.unwrap(),
         conn,
+        time,
         packet,
       }),
       ClientPacket::Command(packet) => game.dispatch(PacketEvent {
         entity: assoc.unwrap(),
         conn,
+        time,
         packet,
       }),
       ClientPacket::ScoreDetailed => game.dispatch(PacketEvent {
         entity: assoc.unwrap(),
         conn,
+        time,
         packet: c::ScoreDetailed,
       }),
       ClientPacket::Chat(packet) => game.dispatch(PacketEvent {
         entity: assoc.unwrap(),
         conn,
+        time,
         packet,
       }),
       ClientPacket::TeamChat(packet) => game.dispatch(PacketEvent {
         entity: assoc.unwrap(),
         conn,
+        time,
         packet,
       }),
       ClientPacket::Whisper(packet) => game.dispatch(PacketEvent {
         entity: assoc.unwrap(),
         conn,
+        time,
         packet,
       }),
       ClientPacket::Say(packet) => game.dispatch(PacketEvent {
         entity: assoc.unwrap(),
         conn,
+        time,
         packet,
       }),
       ClientPacket::VoteMute(packet) => game.dispatch(PacketEvent {
         entity: assoc.unwrap(),
         conn,
+        time,
         packet,
       }),
       ClientPacket::LocalPing(packet) => game.dispatch(PacketEvent {
         entity: assoc.unwrap(),
         conn,
+        time,
         packet,
       }),
     }

--- a/server-next/src/system/ping.rs
+++ b/server-next/src/system/ping.rs
@@ -78,11 +78,8 @@ fn handle_ping_response(event: &PacketEvent<Pong>, game: &mut AirmashGame) {
     None => return,
   };
 
-  let ping: u16 = match data.seq_time(event.packet.num) {
-    Some(time) => (event.time.saturating_duration_since(time))
-      .as_millis()
-      .try_into()
-      .unwrap_or(u16::MAX),
+  let ping = match data.seq_time(event.packet.num) {
+    Some(time) => event.time.saturating_duration_since(time),
     None => return,
   };
 
@@ -96,7 +93,7 @@ fn handle_ping_response(event: &PacketEvent<Pong>, game: &mut AirmashGame) {
   game.send_to(
     event.entity,
     PingResult {
-      ping,
+      ping: ping.as_millis().try_into().unwrap_or(u16::MAX),
       players_game: num_players,
       // TODO: Somehow get the total number of players from a server.
       players_total: num_players,

--- a/server-next/src/system/ping.rs
+++ b/server-next/src/system/ping.rs
@@ -6,7 +6,7 @@ use std::{
 
 use airmash_protocol::client::Pong;
 
-use crate::{component::*, event::PacketEvent, AirmashGame};
+use crate::{component::*, event::PacketEvent, AirmashGame, resource::ServerStats};
 
 struct PingData {
   seqs: VecDeque<(u32, Instant)>,
@@ -73,6 +73,7 @@ fn handle_ping_response(event: &PacketEvent<Pong>, game: &mut AirmashGame) {
   use crate::protocol::server::PingResult;
 
   let this_frame = game.this_frame();
+  let num_players = game.resources.read::<ServerStats>().num_players;
   let data = match game.resources.get::<PingData>() {
     Some(data) => data,
     None => return,
@@ -97,9 +98,9 @@ fn handle_ping_response(event: &PacketEvent<Pong>, game: &mut AirmashGame) {
     event.entity,
     PingResult {
       ping,
-      // TODO
-      players_game: 0,
-      players_total: 0,
+      players_game: num_players,
+      // TODO: Somehow get the total number of players from a server.
+      players_total: num_players,
     },
   )
 }

--- a/server-next/src/util/mod.rs
+++ b/server-next/src/util/mod.rs
@@ -6,7 +6,7 @@ use crate::protocol::{Time, Vector2};
 use crate::resource::*;
 use crate::AirmashGame;
 use nalgebra::vector;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 pub(crate) mod escapes;
 pub mod spectate;
@@ -15,18 +15,23 @@ pub fn convert_time(dur: Duration) -> Time {
   dur.as_secs_f32() * 60.0
 }
 
-pub fn get_current_clock(game: &AirmashGame) -> u32 {
+pub fn get_time_clock(game: &AirmashGame, time: Instant) -> u32 {
   let start_time = game
     .resources
     .get::<StartTime>()
     .expect("StartTime not registered in resources");
+
+  let duration = time.saturating_duration_since(start_time.0);
+  (((duration.as_secs() * 1_000_000) + duration.subsec_micros() as u64) / 10) as u32
+}
+
+pub fn get_current_clock(game: &AirmashGame) -> u32 {
   let this_frame = game
     .resources
     .get::<ThisFrame>()
     .expect("ThisFrame not registered in resources");
 
-  let duration = this_frame.0 - start_time.0;
-  (((duration.as_secs() * 1_000_000) + duration.subsec_micros() as u64) / 10) as u32
+  get_time_clock(game, this_frame.0)
 }
 
 pub fn get_server_upgrades(upgrades: &Upgrades, powerup: &Powerup) -> crate::protocol::Upgrades {


### PR DESCRIPTION
Previously, the estimated ping times by the server were fixed to multiples of the server frame time (16ms). This is obviously wrong so this PR is a set of changes to make it return something closer to the real ping time.