### PR TITLE
Use build config in CI cache key

### DIFF
--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -18,6 +18,8 @@ jobs:
           profile: minimal
           override: true
       - uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ matrix.config }}
       - name: Setup cargo flags
         if: matrix.config == 'release'
         run: |


### PR DESCRIPTION
This ensures that the debug and release jobs don't share caches. This avoids one of them having to rebuild everything every time.