### PR TITLE
Make picking up a powerup grant the corresponding effect

### DIFF
--- a/server-next/src/component/mod.rs
+++ b/server-next/src/component/mod.rs
@@ -1,6 +1,5 @@
 //! Components used within airmash.
 
-use crate::protocol::PowerupType;
 use airmash_protocol::Vector2;
 use bstr::BString;
 use hecs::Entity;
@@ -11,7 +10,7 @@ mod keystate;
 
 pub use self::keystate::KeyState;
 
-pub use crate::protocol::{FlagCode, MobType, PlaneType};
+pub use crate::protocol::{FlagCode, MobType, PlaneType, PowerupType};
 
 def_wrappers! {
   /// The position of an entity.

--- a/server-next/tests/behaviour/mod.rs
+++ b/server-next/tests/behaviour/mod.rs
@@ -1,5 +1,6 @@
 mod admin;
 mod despawn;
+mod powerups;
 mod prowler;
 mod upgrades;
 mod visibility;

--- a/server-next/tests/behaviour/powerups.rs
+++ b/server-next/tests/behaviour/powerups.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
-use server::Vector2;
 use server::component::*;
 use server::test::TestGame;
+use server::Vector2;
 
 #[test]
 fn player_is_upgraded_on_collision_with_upgrade() {
@@ -27,4 +27,32 @@ fn player_is_upgraded_on_collision_with_upgrade() {
   if let Some(data) = &powerup.data {
     assert_eq!(data.ty, PowerupType::Inferno);
   }
+}
+
+#[test]
+fn dual_powerup_collision() {
+  let (mut game, mut mock) = TestGame::new();
+
+  let mut client1 = mock.open();
+  let mut client2 = mock.open();
+
+  let p1 = client1.login("p1", &mut game);
+  let p2 = client2.login("p2", &mut game);
+
+  game.world.get_mut::<Position>(p1).unwrap().0 = Vector2::zeros();
+  game.world.get_mut::<Position>(p2).unwrap().0 = Vector2::zeros();
+
+  game.run_for(Duration::from_secs(4));
+  let powerup = game.spawn_mob(MobType::Inferno, Vector2::zeros(), Duration::from_secs(60));
+  game.run_once();
+
+  assert!(
+    !game.world.contains(powerup),
+    "Powerup was not despawned despite having collided with a player"
+  );
+
+  let p1pow = game.world.get::<Powerup>(p1).unwrap();
+  let p2pow = game.world.get::<Powerup>(p2).unwrap();
+
+  assert!(p1pow.data.is_some() != p2pow.data.is_some());
 }

--- a/server-next/tests/behaviour/powerups.rs
+++ b/server-next/tests/behaviour/powerups.rs
@@ -1,0 +1,30 @@
+use std::time::Duration;
+
+use server::Vector2;
+use server::component::*;
+use server::test::TestGame;
+
+#[test]
+fn player_is_upgraded_on_collision_with_upgrade() {
+  let (mut game, mut mock) = TestGame::new();
+
+  let mut client = mock.open();
+  let player = client.login("test", &mut game);
+  let powerup = game.spawn_mob(MobType::Inferno, Vector2::zeros(), Duration::from_secs(60));
+
+  game.world.get_mut::<Position>(player).unwrap().0 = Vector2::zeros();
+  game.run_once();
+
+  assert!(
+    !game.world.contains(powerup),
+    "Powerup was not despawned despite having collided with a player"
+  );
+
+  let powerup = game.world.get::<Powerup>(player).unwrap();
+
+  assert!(powerup.data.is_some());
+
+  if let Some(data) = &powerup.data {
+    assert_eq!(data.ty, PowerupType::Inferno);
+  }
+}


### PR DESCRIPTION
Currently, if a powerup is spawned and a player goes to pick it up then the powerup will despawn but the player will not be given the corresponding effect. This PR changes that to now give the player the expected effect. I've also included tests to verify that everything works as expected.