### PR TITLE
Change span class used in flag messages to (blue|red)flag

### DIFF
--- a/ctf/src/config.rs
+++ b/ctf/src/config.rs
@@ -44,8 +44,8 @@ pub fn team_respawn_pos(team: u16) -> Vector2<f32> {
 
 pub fn flag_message_team(team: u16) -> &'static str {
   match team {
-    BLUE_TEAM => "blueteam",
-    RED_TEAM => "redteam",
+    BLUE_TEAM => "blueflag",
+    RED_TEAM => "redflag",
     _ => unreachable!(),
   }
 }


### PR DESCRIPTION
The updated client at https://airmash.online now performs HTML escaping for any message not matching a very specific template so in order for the message to be shown properly we need to match that template.