### PR TITLE
Make mohawk missiles fire on alternating sides of the plane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,7 @@ dependencies = [
  "rand",
  "serde",
  "serde-deserialize-over",
+ "serde_json",
  "server-macros",
  "slab",
  "smallvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,6 +643,7 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
+ "serde",
  "simba",
  "typenum",
 ]
@@ -674,6 +675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
 dependencies = [
  "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/configs/default.json
+++ b/configs/default.json
@@ -18,7 +18,10 @@
         "nanos": 550000000
       },
       "missile_type": "PredatorMissile",
-      "missile_offset": 35.0,
+      "missile_offset": [
+        35.0,
+        0.0
+      ],
       "missile_inferno_angle": 0.05,
       "missile_inferno_offset_x": 18.0,
       "missile_inferno_offset_y": 1.25
@@ -41,7 +44,10 @@
         "nanos": 500000000
       },
       "missile_type": "TornadoSingleMissile",
-      "missile_offset": 40.0,
+      "missile_offset": [
+        40.0,
+        0.0
+      ],
       "missile_inferno_angle": 0.05,
       "missile_inferno_offset_x": 15.1,
       "missile_inferno_offset_y": 10.0
@@ -64,7 +70,10 @@
         "nanos": 300000000
       },
       "missile_type": "ProwlerMissile",
-      "missile_offset": 35.0,
+      "missile_offset": [
+        35.0,
+        0.0
+      ],
       "missile_inferno_angle": 0.05,
       "missile_inferno_offset_x": 18.0,
       "missile_inferno_offset_y": 2.25
@@ -87,7 +96,10 @@
         "nanos": 300000000
       },
       "missile_type": "MohawkMissile",
-      "missile_offset": 10.0,
+      "missile_offset": [
+        10.0,
+        15.0
+      ],
       "missile_inferno_angle": 0.1,
       "missile_inferno_offset_x": 0.0,
       "missile_inferno_offset_y": 0.0
@@ -110,7 +122,10 @@
         "nanos": 300000000
       },
       "missile_type": "GoliathMissile",
-      "missile_offset": 35.0,
+      "missile_offset": [
+        35.0,
+        0.0
+      ],
       "missile_inferno_angle": 0.04,
       "missile_inferno_offset_x": 30.0,
       "missile_inferno_offset_y": 2.1
@@ -207,20 +222,76 @@
   },
   "upgrades": {
     "speed": {
-      "cost": [0, 1, 1, 1, 1, 1],
-      "factor": [1.0, 1.05, 1.1, 1.15, 1.2, 1.25]
+      "cost": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "factor": [
+        1.0,
+        1.05,
+        1.1,
+        1.15,
+        1.2,
+        1.25
+      ]
     },
     "missile": {
-      "cost": [0, 1, 1, 1, 1, 1],
-      "factor": [1.0, 1.05, 1.1, 1.15, 1.2, 1.25]
+      "cost": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "factor": [
+        1.0,
+        1.05,
+        1.1,
+        1.15,
+        1.2,
+        1.25
+      ]
     },
     "energy": {
-      "cost": [0, 1, 1, 1, 1, 1],
-      "factor": [1.0, 1.05, 1.1, 1.15, 1.2, 1.25]
+      "cost": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "factor": [
+        1.0,
+        1.05,
+        1.1,
+        1.15,
+        1.2,
+        1.25
+      ]
     },
     "defense": {
-      "cost": [0, 1, 1, 1, 1, 1],
-      "factor": [1.0, 1.05, 1.1, 1.15, 1.2, 1.25]
+      "cost": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "factor": [
+        1.0,
+        1.05,
+        1.1,
+        1.15,
+        1.2,
+        1.25
+      ]
     }
   },
   "admin_enabled": true,
@@ -237,5 +308,9 @@
     "secs": 10,
     "nanos": 0
   },
-  "view_radius": 2250.0
+  "view_radius": 2250.0,
+  "respawn_delay": {
+    "secs": 2,
+    "nanos": 0
+  }
 }

--- a/server-next/Cargo.toml
+++ b/server-next/Cargo.toml
@@ -46,3 +46,4 @@ features = [ "serde" ]
 
 [dev-dependencies]
 approx = "0.5"
+serde_json = "1.0"

--- a/server-next/Cargo.toml
+++ b/server-next/Cargo.toml
@@ -8,7 +8,7 @@ mt-network = []
 
 [dependencies]
 hecs = "0.7.6"
-nalgebra = "0.30.1"
+nalgebra = { version = "0.30.1", features = ["serde-serialize"] }
 anymap = "0.12"
 linkme = "0.2.6"
 log = "0.4"

--- a/server-next/examples/export-config.rs
+++ b/server-next/examples/export-config.rs
@@ -1,0 +1,8 @@
+use airmash_server::resource::Config;
+
+fn main() {
+  let config = Config::default();
+
+  serde_json::to_writer_pretty(std::io::stdout(), &config).expect("Failed to serialize config");
+  println!("");
+}

--- a/server-next/src/component/mod.rs
+++ b/server-next/src/component/mod.rs
@@ -239,3 +239,20 @@ impl From<IsAlive> for crate::protocol::PlayerStatus {
     }
   }
 }
+
+/// The side from which the next missile from this player will be fired. This
+/// alternates every time the player fires.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum MissileFiringSide {
+  Left,
+  Right,
+}
+
+impl MissileFiringSide {
+  pub fn reverse(self) -> Self {
+    match self {
+      Self::Left => Self::Right,
+      Self::Right => Self::Left,
+    }
+  }
+}

--- a/server-next/src/defaults.rs
+++ b/server-next/src/defaults.rs
@@ -58,7 +58,8 @@ pub(crate) fn build_default_player(
     .add(Spectating::default())
     .add(PlayerPing(Duration::ZERO))
     .add(TotalDamage(0.0))
-    .add(Captures(0));
+    .add(Captures(0))
+    .add(MissileFiringSide::Left);
 
   builder
 }

--- a/server-next/src/resource/config.rs
+++ b/server-next/src/resource/config.rs
@@ -43,7 +43,7 @@ pub struct PlaneInfo {
   pub missile_type: Mob,
   // Offset of missile relative to the plane when fired.
   //
-  // The horizontal (X) offset will alternate sides with every shot.
+  // The horizontal (Y) offset will alternate sides with every shot.
   pub missile_offset: Vector2<Distance>,
 
   // Angle and displacement of the other two missiles when inferno firing

--- a/server-next/src/resource/config.rs
+++ b/server-next/src/resource/config.rs
@@ -1,5 +1,6 @@
 //! Configuration info controlling how planes and missiles behave.
 
+use nalgebra::vector;
 use serde_deserialize_over::DeserializeOver;
 use std::ops::Index;
 use std::time::Duration;
@@ -9,6 +10,7 @@ use crate::protocol::{
   AccelScalar, Distance, Energy, EnergyRegen, Health, HealthRegen, MobType as Mob,
   PlaneType as Plane, Rotation, RotationRate, Speed,
 };
+use crate::Vector2;
 
 #[derive(Debug, Clone, Serialize, Deserialize, DeserializeOver)]
 pub struct PlaneInfo {
@@ -39,8 +41,10 @@ pub struct PlaneInfo {
 
   // Type of missile that the plane fires
   pub missile_type: Mob,
-  // Offset of missile (in the Y dir) when fired
-  pub missile_offset: Distance,
+  // Offset of missile relative to the plane when fired.
+  //
+  // The horizontal (X) offset will alternate sides with every shot.
+  pub missile_offset: Vector2<Distance>,
 
   // Angle and displacement of the other two missiles when inferno firing
   // (assuming symmetry around central missile)
@@ -294,7 +298,7 @@ mod plane_defaults {
       fire_energy: 0.6,
 
       missile_type: MobType::PredatorMissile,
-      missile_offset: 35.0,
+      missile_offset: vector![35.0, 0.0],
 
       missile_inferno_angle: 0.05,
       missile_inferno_offset_x: 18.0,
@@ -323,7 +327,7 @@ mod plane_defaults {
       fire_energy: 0.9,
 
       missile_type: MobType::GoliathMissile,
-      missile_offset: 35.0,
+      missile_offset: vector![35.0, 0.0],
 
       missile_inferno_angle: 0.04,
       missile_inferno_offset_x: 30.0,
@@ -353,7 +357,7 @@ mod plane_defaults {
 
       missile_type: MobType::MohawkMissile,
       // This will have to be a special case
-      missile_offset: 10.0,
+      missile_offset: vector![10.0, 15.0],
 
       missile_inferno_angle: 0.1,
       missile_inferno_offset_x: 0.0,
@@ -382,7 +386,7 @@ mod plane_defaults {
       fire_energy: 0.5,
 
       missile_type: MobType::TornadoSingleMissile,
-      missile_offset: 40.0,
+      missile_offset: vector![40.0, 0.0],
 
       missile_inferno_angle: 0.05,
       missile_inferno_offset_x: 15.1,
@@ -411,7 +415,7 @@ mod plane_defaults {
       fire_energy: 0.75,
 
       missile_type: MobType::ProwlerMissile,
-      missile_offset: 35.0,
+      missile_offset: vector![35.0, 0.0],
 
       missile_inferno_angle: 0.05,
       missile_inferno_offset_x: 18.0,

--- a/server-next/tests/behaviour/visibility.rs
+++ b/server-next/tests/behaviour/visibility.rs
@@ -60,10 +60,10 @@ fn out_of_visibility_collision() {
 
   let offset = {
     let mut config = game.resources.write::<Config>();
-    config.planes.predator.missile_offset = 500.0;
+    config.planes.predator.missile_offset.x = 500.0;
     config.view_radius = 100.0;
 
-    config.planes.predator.missile_offset
+    config.planes.predator.missile_offset.x
   };
 
   let mut client1 = mock.open();


### PR DESCRIPTION
Currently, all missiles from all planes are fired from the centre of the plane. However, this is not correct for the mohawk which is supposed to fire with the offset switching sides with each shot. This PR adds this behaviour. Note that this involves a change to the config so I've added a small utility to export the default config and then gone and updated it.