### PR TITLE
Change the serialized form of durations to be a float

### DIFF
--- a/configs/default.json
+++ b/configs/default.json
@@ -13,10 +13,7 @@
       "energy_regen": 0.008,
       "damage_factor": 2.0,
       "fire_energy": 0.6,
-      "fire_delay": {
-        "secs": 0,
-        "nanos": 550000000
-      },
+      "fire_delay": 0.55,
       "missile_type": "PredatorMissile",
       "missile_offset": [
         35.0,
@@ -39,10 +36,7 @@
       "energy_regen": 0.006,
       "damage_factor": 1.6666666,
       "fire_energy": 0.5,
-      "fire_delay": {
-        "secs": 0,
-        "nanos": 500000000
-      },
+      "fire_delay": 0.5,
       "missile_type": "TornadoSingleMissile",
       "missile_offset": [
         40.0,
@@ -65,10 +59,7 @@
       "energy_regen": 0.006,
       "damage_factor": 1.6666666,
       "fire_energy": 0.75,
-      "fire_delay": {
-        "secs": 0,
-        "nanos": 300000000
-      },
+      "fire_delay": 0.3,
       "missile_type": "ProwlerMissile",
       "missile_offset": [
         35.0,
@@ -91,10 +82,7 @@
       "energy_regen": 0.01,
       "damage_factor": 2.6375,
       "fire_energy": 0.3,
-      "fire_delay": {
-        "secs": 0,
-        "nanos": 300000000
-      },
+      "fire_delay": 0.3,
       "missile_type": "MohawkMissile",
       "missile_offset": [
         10.0,
@@ -117,10 +105,7 @@
       "energy_regen": 0.005,
       "damage_factor": 1.0,
       "fire_energy": 0.9,
-      "fire_delay": {
-        "secs": 0,
-        "nanos": 300000000
-      },
+      "fire_delay": 0.3,
       "missile_type": "GoliathMissile",
       "missile_offset": [
         35.0,
@@ -199,24 +184,15 @@
       }
     },
     "upgrade": {
-      "lifetime": {
-        "secs": 60,
-        "nanos": 0
-      },
+      "lifetime": 60.0,
       "missile": null
     },
     "inferno": {
-      "lifetime": {
-        "secs": 60,
-        "nanos": 0
-      },
+      "lifetime": 60.0,
       "missile": null
     },
     "shield": {
-      "lifetime": {
-        "secs": 60,
-        "nanos": 0
-      },
+      "lifetime": 60.0,
       "missile": null
     }
   },
@@ -296,21 +272,9 @@
   },
   "admin_enabled": false,
   "allow_spectate_while_moving": true,
-  "spawn_shield_duration": {
-    "secs": 2,
-    "nanos": 0
-  },
-  "shield_duration": {
-    "secs": 10,
-    "nanos": 0
-  },
-  "inferno_duration": {
-    "secs": 10,
-    "nanos": 0
-  },
+  "spawn_shield_duration": 2.0,
+  "shield_duration": 10.0,
+  "inferno_duration": 10.0,
   "view_radius": 2250.0,
-  "respawn_delay": {
-    "secs": 2,
-    "nanos": 0
-  }
+  "respawn_delay": 2.0
 }

--- a/configs/infinite-fire.json
+++ b/configs/infinite-fire.json
@@ -1,23 +1,23 @@
 {
   "planes": {
     "predator": {
-      "fire_delay": { "secs": 0, "nanos": 0 },
+      "fire_delay": 0.0,
       "fire_energy": 0
     },
     "tornado": {
-      "fire_delay": { "secs": 0, "nanos": 0 },
+      "fire_delay": 0.0,
       "fire_energy": 0
     },
     "prowler": {
-      "fire_delay": { "secs": 0, "nanos": 0 },
+      "fire_delay": 0.0,
       "fire_energy": 0
     },
     "mohawk": {
-      "fire_delay": { "secs": 0, "nanos": 0 },
+      "fire_delay": 0.0,
       "fire_energy": 0
     },
     "goliath": {
-      "fire_delay": { "secs": 0, "nanos": 0 },
+      "fire_delay": 0.0,
       "fire_energy": 0
     }
   },

--- a/configs/stress-test.json
+++ b/configs/stress-test.json
@@ -2,38 +2,23 @@
   "planes": {
     "predator": {
       "fire_energy": 0.0,
-      "fire_delay": {
-        "secs": 0,
-        "nanos": 0
-      }
+      "fire_delay": 0.0
     },
     "tornado": {
       "fire_energy": 0.0,
-      "fire_delay": {
-        "secs": 0,
-        "nanos": 0
-      }
+      "fire_delay": 0.0
     },
     "prowler": {
       "fire_energy": 0.0,
-      "fire_delay": {
-        "secs": 0,
-        "nanos": 0
-      }
+      "fire_delay": 0.0
     },
     "mohawk": {
       "fire_energy": 0.0,
-      "fire_delay": {
-        "secs": 0,
-        "nanos": 0
-      }
+      "fire_delay": 0.0
     },
     "goliath": {
       "fire_energy": 0.0,
-      "fire_delay": {
-        "secs": 0,
-        "nanos": 0
-      }
+      "fire_delay": 0.0
     }
   }
 }

--- a/server-next/Cargo.toml
+++ b/server-next/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { version="1.0", features=["rt", "sync", "io-util", "macros", "time", "r
 tokio-tungstenite = "0.17.1"
 
 serde = { version = "1.0", features = ["derive"] }
-serde-deserialize-over = "0.1.0"
+serde-deserialize-over = "0.1.1"
 
 server-macros = { path="../server-macros" }
 kdtree = { path="../utils/kdtree" }


### PR DESCRIPTION
As in title. This required some pretty big changes to `serde-deserialize-over` but now that those have been made we can make the config easier to write and understand.