### PR TITLE
Bump anymap from 0.12.1 to 1.0.0-beta.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "anymap"
-version = "0.12.1"
+version = "1.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
+checksum = "8f1f8f5a6f3d50d89e3797d7593a50f96bb2aaa20ca0cc7be1fb673232c91d72"
 
 [[package]]
 name = "approx"

--- a/server-next/Cargo.toml
+++ b/server-next/Cargo.toml
@@ -9,7 +9,7 @@ mt-network = []
 [dependencies]
 hecs = "0.7.6"
 nalgebra = { version = "0.30.1", features = ["serde-serialize"] }
-anymap = "0.12"
+anymap = "=1.0.0-beta.2"
 linkme = "0.2.6"
 log = "0.4"
 crossbeam-channel = "0.5"

--- a/server-next/src/world.rs
+++ b/server-next/src/world.rs
@@ -282,7 +282,7 @@ impl Resources {
 
 /// A view into a single location in the [`Resources`] map.
 pub struct ResourceEntry<'a, T> {
-  entry: anymap::Entry<'a, dyn anymap::any::Any, RefCell<T>>,
+  entry: anymap::Entry<'a, dyn std::any::Any, RefCell<T>>,
 }
 
 impl<'a, T: 'static> ResourceEntry<'a, T> {


### PR DESCRIPTION
Anymap 0.12.1 is insecure but there's no non-beta updated version so instead we'll be using the beta version for now