### PR TITLE
Update both nalgebra and airmash-protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "airmash-protocol"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5d44815298b5cf0b71372d52e82a42c3d64c38278744c1769ede18860b80d"
+checksum = "3c4c1d292226e1a0c8fcb1d5d2f2c50299905d04503544210ac084ca79e4875c"
 dependencies = [
  "bstr",
  "derivative",
@@ -672,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.30.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb2d0de08694bed883320212c18ee3008576bfe8c306f4c3c4a58b4876998be"
+checksum = "18a89248335f688e4bd994e6d030fd7e185eb41769b8c435395075425e100ac6"
 dependencies = [
  "approx",
  "matrixmultiply",

--- a/server-next/Cargo.toml
+++ b/server-next/Cargo.toml
@@ -8,7 +8,7 @@ mt-network = []
 
 [dependencies]
 hecs = "0.7.6"
-nalgebra = { version = "0.30.1", features = ["serde-serialize"] }
+nalgebra = { version = "0.31.0", features = ["serde-serialize"] }
 anymap = "=1.0.0-beta.2"
 linkme = "0.2.6"
 log = "0.4"
@@ -28,6 +28,7 @@ tokio-tungstenite = "0.17.1"
 serde = { version = "1.0", features = ["derive"] }
 serde-deserialize-over = "0.1.1"
 
+airmash-protocol = { version = "0.5.0", features = ["serde"] }
 server-macros = { path="../server-macros" }
 kdtree = { path="../utils/kdtree" }
 
@@ -46,7 +47,3 @@ features = [ "sink" ]
 [dependencies.futures-task]
 version = "0.3"
 default-features = false
-
-[dependencies.airmash-protocol]
-version = "0.4.0"
-features = [ "serde" ]


### PR DESCRIPTION
These need to be updated in lockstep since they are exposed as part of airmash-protocol's API