### PR TITLE
Add support for firing arbitrary numbers of missiles from planes

### DIFF
--- a/server-next/src/component/mod.rs
+++ b/server-next/src/component/mod.rs
@@ -255,4 +255,11 @@ impl MissileFiringSide {
       Self::Right => Self::Left,
     }
   }
+
+  pub fn multiplier(self) -> f32 {
+    match self {
+      Self::Left => -1.0,
+      Self::Right => 1.0,
+    }
+  }
 }

--- a/server-next/src/system/specials.rs
+++ b/server-next/src/system/specials.rs
@@ -1,4 +1,3 @@
-use hecs::Entity;
 use smallvec::SmallVec;
 
 use crate::{
@@ -10,7 +9,7 @@ use crate::{
     collision::{LayerSpec, MissileCollideDb, PlayerCollideDb},
     Config,
   },
-  AirmashGame, FireMissileInfo,
+  AirmashGame,
 };
 
 pub fn update(game: &mut AirmashGame) {
@@ -69,7 +68,7 @@ fn tornado_special_fire(game: &mut AirmashGame) {
     )>()
     .with::<IsPlayer>();
 
-  let mut events: Vec<(Entity, SmallVec<[FireMissileInfo; 5]>)> = Vec::new();
+  let mut events = Vec::new();
   for (ent, (keystate, last_fire, energy, &plane, powerup, alive)) in query.iter() {
     if plane != PlaneType::Tornado || !keystate.special || !alive.0 {
       continue;
@@ -86,7 +85,7 @@ fn tornado_special_fire(game: &mut AirmashGame) {
 
     energy.0 -= TORNADO_SPECIAL_ENERGY;
 
-    let mut missiles = SmallVec::new();
+    let mut missiles = SmallVec::<[_; 5]>::new();
     if powerup.inferno() {
       missiles.extend_from_slice(&TORNADO_INFERNO_MISSILE_DETAILS[..]);
     } else {


### PR DESCRIPTION
I'd like to support modes where the game is more easily modifiable through config files. This PR is one part of this whole effort. At the moment it doesn't add new capabilities but it does make experimenting with missile multi-shot from planes much easier.

Note that it's not yet used for the tornado special since the current config setup has the offsets for missiles associated with the plane and not the missile type.