### PR TITLE
Convert dependabot automerge workflow to use pull_request

### DIFF
--- a/.github/workflows/auto-dependabot.yml
+++ b/.github/workflows/auto-dependabot.yml
@@ -1,5 +1,7 @@
 name: Auto-merge compatible dependabot PRs
-on: pull_request
+on: 
+  pull_request:
+    branches: 'dependabot/**'
 permissions: write-all
 
 jobs:

--- a/.github/workflows/auto-dependabot.yml
+++ b/.github/workflows/auto-dependabot.yml
@@ -1,7 +1,6 @@
 name: Auto-merge compatible dependabot PRs
-on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+on: pull_request
+permissions: write-all
 
 jobs:
   auto-merge:


### PR DESCRIPTION
pull_request_target workflows are not given access to any dependabot secrets at all so they will not work.