### PR TITLE
Introduce a crate to serialize/deserialize from rlua Values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,6 +846,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,6 +951,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
+name = "rlua"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a8b33d82d6653c447e40067dcf3c970b76e6ebf13807f6acee934f06cc2e35e"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "libc",
+ "num-traits",
+ "rlua-lua54-sys",
+]
+
+[[package]]
+name = "rlua-lua54-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca23c19a6782d115dce7e11be719b4dbea833acd0d0599e963abf4f31ad9137"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,6 +1032,14 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89b56c640df910a470a1d9992e4b3da2b8d638d7cbc3717c7ebc4d626add290"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde-rlua"
+version = "0.1.0"
+dependencies = [
+ "rlua",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ members = [
 	"ffa",
 	"server",
 	"server-macros",
-	"utils/kdtree"
+	"utils/kdtree",
+	"utils/serde-rlua"
 ]

--- a/utils/serde-rlua/Cargo.toml
+++ b/utils/serde-rlua/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "serde-rlua"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = "1.0"
+rlua = "0.19"
+
+[dev-dependencies]
+serde = { version = "1.0", features = [ "derive" ] }

--- a/utils/serde-rlua/src/de.rs
+++ b/utils/serde-rlua/src/de.rs
@@ -12,6 +12,7 @@ impl<'lua> FromLua<'lua> for Empty {
   }
 }
 
+/// Deserializer from rlua `Value`s.
 pub struct LuaDeserializer<'lua> {
   value: Value<'lua>,
 }

--- a/utils/serde-rlua/src/de.rs
+++ b/utils/serde-rlua/src/de.rs
@@ -1,0 +1,512 @@
+use rlua::{FromLua, TablePairs, TableSequence, Value};
+use serde::de::{self, Deserializer, IntoDeserializer as _};
+use serde::forward_to_deserialize_any;
+
+use super::Error;
+
+struct Empty;
+
+impl<'lua> FromLua<'lua> for Empty {
+  fn from_lua(_: Value<'lua>, _: rlua::Context<'lua>) -> rlua::Result<Self> {
+    Ok(Self)
+  }
+}
+
+pub struct LuaDeserializer<'lua> {
+  value: Value<'lua>,
+}
+
+impl<'lua> LuaDeserializer<'lua> {
+  pub fn new(value: Value<'lua>) -> Self {
+    Self { value }
+  }
+
+  fn invalid_type<E, U>(value: Value<'lua>, expected: E) -> Result<U, Error>
+  where
+    E: de::Expected,
+  {
+    use serde::de::{Error, Unexpected};
+
+    #[rustfmt::skip]
+    let unexpected: Unexpected = match value {
+      Value::Boolean(v)       => Unexpected::Bool(v),
+      Value::Number(v)         => Unexpected::Float(v),
+      Value::Integer(v)        => Unexpected::Signed(v),
+      Value::String(ref v) => Unexpected::Str(v.to_str()?),
+      Value::Nil                    => Unexpected::Unit,
+      Value::Table(_)               => Unexpected::Map,
+      Value::Thread(_)              => Unexpected::Other("thread"),
+      Value::LightUserData(_)       => Unexpected::Other("userdata"),
+      Value::UserData(_)            => Unexpected::Other("userdata"),
+      Value::Function(_)            => Unexpected::Other("function"),
+      Value::Error(_)               => Unexpected::Other("error"),
+    };
+
+    Err(Error::invalid_type(unexpected, &expected))
+  }
+}
+
+impl<'lua, 'de> Deserializer<'de> for LuaDeserializer<'lua> {
+  type Error = Error;
+
+  fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+  where
+    V: de::Visitor<'de>,
+  {
+    match self.value {
+      Value::Nil => visitor.visit_unit(),
+      Value::Boolean(v) => visitor.visit_bool(v),
+      Value::Integer(v) => visitor.visit_i64(v),
+      Value::Number(v) => visitor.visit_f64(v),
+      Value::String(v) => visitor.visit_str(v.to_str()?),
+      Value::Table(table) => {
+        let len = table.raw_len() as usize;
+
+        if len == 0 {
+          return visitor.visit_map(MapDeserializer::new(table.pairs()));
+        }
+
+        if table
+          .clone()
+          .pairs::<Empty, Empty>()
+          .skip(len)
+          .next()
+          .is_some()
+        {
+          visitor.visit_map(MapDeserializer::new(table.pairs()))
+        } else {
+          visitor.visit_seq(SeqDeserializer(table.sequence_values()))
+        }
+      }
+      value => Self::invalid_type(value, "value type"),
+    }
+  }
+
+  fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+  where
+    V: de::Visitor<'de>,
+  {
+    match self.value {
+      Value::Nil => visitor.visit_none(),
+      _ => visitor.visit_unit(),
+    }
+  }
+
+  fn deserialize_enum<V>(
+    self,
+    _name: &'static str,
+    _variants: &'static [&'static str],
+    visitor: V,
+  ) -> Result<V::Value, Self::Error>
+  where
+    V: de::Visitor<'de>,
+  {
+    let (variant, value) = match self.value {
+      Value::Table(value) => {
+        let mut iter = value.pairs::<String, Value>();
+        let (variant, value) = match iter.next() {
+          Some(v) => v?,
+          None => {
+            return Err(de::Error::invalid_value(
+              de::Unexpected::Map,
+              &"map with a single key",
+            ))
+          }
+        };
+
+        if iter.next().is_some() {
+          return Err(de::Error::invalid_value(
+            de::Unexpected::Map,
+            &"map with a single key",
+          ));
+        }
+
+        (variant, Some(value))
+      }
+      Value::String(variant) => (variant.to_str()?.to_owned(), None),
+      value => return Self::invalid_type(value, visitor),
+    };
+
+    visitor.visit_enum(EnumDeserializer { variant, value })
+  }
+
+  fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+  where
+    V: de::Visitor<'de>,
+  {
+    match self.value {
+      Value::Table(v) => {
+        let len = v.len()? as usize;
+        let mut de = SeqDeserializer(v.sequence_values());
+        let seq = visitor.visit_seq(&mut de)?;
+
+        match de.0.count() {
+          0 => return Ok(seq),
+          n => Err(de::Error::custom(format_args!(
+            "invalid length {}, expected sequence with {} elements",
+            len,
+            len - n
+          ))),
+        }
+      }
+      value => Self::invalid_type(value, "sequence"),
+    }
+  }
+
+  fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+  where
+    V: de::Visitor<'de>,
+  {
+    match self.value {
+      Value::Table(table) => visitor.visit_map(MapDeserializer::new(table.pairs())),
+      value => Self::invalid_type(value, visitor),
+    }
+  }
+
+  fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+  where
+    V: de::Visitor<'de>,
+  {
+    self.deserialize_seq(visitor)
+  }
+
+  fn deserialize_tuple_struct<V>(
+    self,
+    _name: &'static str,
+    _len: usize,
+    visitor: V,
+  ) -> Result<V::Value, Self::Error>
+  where
+    V: de::Visitor<'de>,
+  {
+    self.deserialize_seq(visitor)
+  }
+
+  forward_to_deserialize_any! {
+    bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string bytes
+    byte_buf unit unit_struct newtype_struct
+    struct identifier ignored_any
+  }
+}
+
+struct SeqDeserializer<'lua>(TableSequence<'lua, Value<'lua>>);
+
+impl<'lua, 'de> de::SeqAccess<'de> for SeqDeserializer<'lua> {
+  type Error = Error;
+
+  fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+  where
+    T: de::DeserializeSeed<'de>,
+  {
+    Ok(match self.0.next() {
+      Some(value) => Some(seed.deserialize(LuaDeserializer::new(value?))?),
+      None => None,
+    })
+  }
+
+  fn size_hint(&self) -> Option<usize> {
+    match self.0.size_hint() {
+      (lower, Some(upper)) if lower == upper => Some(upper),
+      _ => None,
+    }
+  }
+}
+
+struct MapDeserializer<'lua> {
+  iter: TablePairs<'lua, Value<'lua>, Value<'lua>>,
+  value: Option<Value<'lua>>,
+}
+
+impl<'lua> MapDeserializer<'lua> {
+  pub fn new(iter: TablePairs<'lua, Value<'lua>, Value<'lua>>) -> Self {
+    Self { iter, value: None }
+  }
+}
+
+impl<'lua, 'de> de::MapAccess<'de> for MapDeserializer<'lua> {
+  type Error = Error;
+
+  fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+  where
+    K: de::DeserializeSeed<'de>,
+  {
+    Ok(match self.iter.next() {
+      Some(item) => {
+        let (key, value) = item?;
+        self.value = Some(value);
+
+        Some(seed.deserialize(LuaDeserializer::new(key))?)
+      }
+      None => None,
+    })
+  }
+
+  fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+  where
+    V: de::DeserializeSeed<'de>,
+  {
+    let value = self
+      .value
+      .take()
+      .expect("next_value_seed called before next_key_seed");
+
+    seed.deserialize(LuaDeserializer::new(value))
+  }
+
+  fn next_entry_seed<K, V>(
+    &mut self,
+    kseed: K,
+    vseed: V,
+  ) -> Result<Option<(K::Value, V::Value)>, Self::Error>
+  where
+    K: de::DeserializeSeed<'de>,
+    V: de::DeserializeSeed<'de>,
+  {
+    Ok(match self.iter.next() {
+      Some(item) => {
+        let (key, value) = item?;
+
+        let key = kseed.deserialize(LuaDeserializer::new(key))?;
+        let val = vseed.deserialize(LuaDeserializer::new(value))?;
+
+        Some((key, val))
+      }
+      None => None,
+    })
+  }
+
+  fn size_hint(&self) -> Option<usize> {
+    match self.iter.size_hint() {
+      (lower, Some(upper)) if lower == upper => Some(upper),
+      _ => None,
+    }
+  }
+}
+
+struct EnumDeserializer<'lua> {
+  variant: String,
+  value: Option<Value<'lua>>,
+}
+
+impl<'lua, 'de> de::EnumAccess<'de> for EnumDeserializer<'lua> {
+  type Error = Error;
+  type Variant = VariantDeserializer<'lua>;
+
+  fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+  where
+    V: de::DeserializeSeed<'de>,
+  {
+    let variant = self.variant.into_deserializer();
+    let access = VariantDeserializer(self.value);
+
+    seed.deserialize(variant).map(move |v| (v, access))
+  }
+}
+
+struct VariantDeserializer<'lua>(Option<Value<'lua>>);
+
+impl<'lua, 'de> de::VariantAccess<'de> for VariantDeserializer<'lua> {
+  type Error = Error;
+
+  fn unit_variant(self) -> Result<(), Self::Error> {
+    match self.0 {
+      Some(_) => Err(de::Error::invalid_type(
+        de::Unexpected::NewtypeVariant,
+        &"unit variant",
+      )),
+      None => Ok(()),
+    }
+  }
+
+  fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+  where
+    T: de::DeserializeSeed<'de>,
+  {
+    match self.0 {
+      Some(value) => seed.deserialize(LuaDeserializer::new(value)),
+      None => Err(de::Error::invalid_type(
+        de::Unexpected::UnitVariant,
+        &"newtype variant",
+      )),
+    }
+  }
+
+  fn tuple_variant<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
+  where
+    V: de::Visitor<'de>,
+  {
+    match self.0 {
+      Some(value) => LuaDeserializer::new(value).deserialize_tuple(len, visitor),
+      None => Err(de::Error::invalid_type(
+        de::Unexpected::UnitVariant,
+        &"tuple variant",
+      )),
+    }
+  }
+
+  fn struct_variant<V>(
+    self,
+    _fields: &'static [&'static str],
+    visitor: V,
+  ) -> Result<V::Value, Self::Error>
+  where
+    V: de::Visitor<'de>,
+  {
+    match self.0 {
+      Some(value) => LuaDeserializer::new(value).deserialize_map(visitor),
+      None => Err(de::Error::invalid_type(
+        de::Unexpected::UnitVariant,
+        &"struct variant",
+      )),
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use rlua::Lua;
+
+  use super::super::from_value;
+
+  #[test]
+  fn test_struct() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct Test {
+      int: u32,
+      seq: Vec<String>,
+      map: std::collections::HashMap<i32, i32>,
+      empty: Vec<()>,
+    }
+
+    let expected = Test {
+      int: 1,
+      seq: vec!["a".to_owned(), "b".to_owned()],
+      map: vec![(1, 2), (4, 1)].into_iter().collect(),
+      empty: vec![],
+    };
+
+    println!("{:?}", expected);
+    let lua = Lua::new();
+    lua.context(|lua| {
+      let value = lua
+        .load(
+          r#"
+                a = {}
+                a.int = 1
+                a.seq = {"a", "b"}
+                a.map = {2, [4]=1}
+                a.empty = {}
+                return a
+            "#,
+        )
+        .eval()
+        .unwrap();
+      let got = from_value(value).unwrap();
+      assert_eq!(expected, got);
+    });
+  }
+
+  #[test]
+  fn test_tuple() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct Rgb(u8, u8, u8);
+
+    let lua = Lua::new();
+    lua.context(|lua| {
+      let expected = Rgb(1, 2, 3);
+      let value = lua
+        .load(
+          r#"
+                a = {1, 2, 3}
+                return a
+            "#,
+        )
+        .eval()
+        .unwrap();
+      let got = from_value(value).unwrap();
+      assert_eq!(expected, got);
+
+      let expected = (1, 2, 3);
+      let value = lua
+        .load(
+          r#"
+                a = {1, 2, 3}
+                return a
+            "#,
+        )
+        .eval()
+        .unwrap();
+      let got = from_value(value).unwrap();
+      assert_eq!(expected, got);
+    });
+  }
+
+  #[test]
+  fn test_enum() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    enum E {
+      Unit,
+      Newtype(u32),
+      Tuple(u32, u32),
+      Struct { a: u32 },
+    }
+
+    let lua = Lua::new();
+    lua.context(|lua| {
+      let expected = E::Unit;
+      let value = lua
+        .load(
+          r#"
+                return "Unit"
+            "#,
+        )
+        .eval()
+        .unwrap();
+      let got = from_value(value).unwrap();
+      assert_eq!(expected, got);
+
+      let expected = E::Newtype(1);
+      let value = lua
+        .load(
+          r#"
+                a = {}
+                a["Newtype"] = 1
+                return a
+            "#,
+        )
+        .eval()
+        .unwrap();
+      let got = from_value(value).unwrap();
+      assert_eq!(expected, got);
+
+      let expected = E::Tuple(1, 2);
+      let value = lua
+        .load(
+          r#"
+                a = {}
+                a["Tuple"] = {1, 2}
+                return a
+            "#,
+        )
+        .eval()
+        .unwrap();
+      let got = from_value(value).unwrap();
+      assert_eq!(expected, got);
+
+      let expected = E::Struct { a: 1 };
+      let value = lua
+        .load(
+          r#"
+                a = {}
+                a["Struct"] = {}
+                a["Struct"]["a"] = 1
+                return a
+            "#,
+        )
+        .eval()
+        .unwrap();
+      let got = from_value(value).unwrap();
+      assert_eq!(expected, got);
+    });
+  }
+}

--- a/utils/serde-rlua/src/de.rs
+++ b/utils/serde-rlua/src/de.rs
@@ -70,8 +70,7 @@ impl<'lua, 'de> Deserializer<'de> for LuaDeserializer<'lua> {
         if table
           .clone()
           .pairs::<Empty, Empty>()
-          .skip(len)
-          .next()
+          .nth(len)
           .is_some()
         {
           visitor.visit_map(MapDeserializer::new(table.pairs()))
@@ -142,7 +141,7 @@ impl<'lua, 'de> Deserializer<'de> for LuaDeserializer<'lua> {
         let seq = visitor.visit_seq(&mut de)?;
 
         match de.0.count() {
-          0 => return Ok(seq),
+          0 => Ok(seq),
           n => Err(de::Error::custom(format_args!(
             "invalid length {}, expected sequence with {} elements",
             len,

--- a/utils/serde-rlua/src/de.rs
+++ b/utils/serde-rlua/src/de.rs
@@ -67,12 +67,7 @@ impl<'lua, 'de> Deserializer<'de> for LuaDeserializer<'lua> {
           return visitor.visit_map(MapDeserializer::new(table.pairs()));
         }
 
-        if table
-          .clone()
-          .pairs::<Empty, Empty>()
-          .nth(len)
-          .is_some()
-        {
+        if table.clone().pairs::<Empty, Empty>().nth(len).is_some() {
           visitor.visit_map(MapDeserializer::new(table.pairs()))
         } else {
           visitor.visit_seq(SeqDeserializer(table.sequence_values()))

--- a/utils/serde-rlua/src/error.rs
+++ b/utils/serde-rlua/src/error.rs
@@ -1,0 +1,58 @@
+use std::error::Error as StdError;
+use std::fmt;
+
+use rlua::Error as LuaError;
+use serde::{de, ser};
+
+#[derive(Clone, Debug)]
+pub struct Error(LuaError);
+
+impl From<LuaError> for Error {
+  fn from(e: LuaError) -> Self {
+    Self(e)
+  }
+}
+
+impl From<Error> for LuaError {
+  fn from(e: Error) -> Self {
+    e.0
+  }
+}
+
+impl fmt::Display for Error {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    self.0.fmt(f)
+  }
+}
+
+impl StdError for Error {
+  fn source(&self) -> Option<&(dyn StdError + 'static)> {
+    Some(&self.0)
+  }
+}
+
+impl ser::Error for Error {
+  fn custom<T>(msg: T) -> Self
+  where
+    T: fmt::Display,
+  {
+    Self(LuaError::ToLuaConversionError {
+      from: "serialize",
+      to: "value",
+      message: Some(msg.to_string()),
+    })
+  }
+}
+
+impl de::Error for Error {
+  fn custom<T>(msg: T) -> Self
+  where
+    T: fmt::Display,
+  {
+    Self(LuaError::FromLuaConversionError {
+      from: "value",
+      to: "deserialize",
+      message: Some(msg.to_string()),
+    })
+  }
+}

--- a/utils/serde-rlua/src/error.rs
+++ b/utils/serde-rlua/src/error.rs
@@ -4,6 +4,20 @@ use std::fmt;
 use rlua::Error as LuaError;
 use serde::{de, ser};
 
+/// Error for when a conversion between rust values and [`rlua`] [`Value`]s
+/// fails.
+///
+/// This type is just a wrapper around [`rlua::Error`] that provides some useful
+/// trait implementations as needed by the [`Serializer`] and [`Deserializer`]
+/// types. Usually you won't want to use this type but instead just convert it
+/// directly to [`rlua::Error`]. The [`to_value`] and [`from_value`] helper
+/// methods will do this for you.
+///
+/// [`Value`]: rlua::Value
+/// [`Serializer`]: crate::Serializer
+/// [`Deserializer`]: crate::Deserializer
+/// [`to_value`]: crate::to_value
+/// [`from_value`]: crate::from_value
 #[derive(Clone, Debug)]
 pub struct Error(LuaError);
 

--- a/utils/serde-rlua/src/lib.rs
+++ b/utils/serde-rlua/src/lib.rs
@@ -1,5 +1,12 @@
-//! This module is more or less a port of rlua_serde to work with the most
-//! recent rlua and also to fix some small nits around how it produces errors.
+//! Serde serializers and deserializers for deserializing to and from [`rlua`]
+//! [`Value`]s.
+//!
+//! It is more or less a port of [`rlua_serde`] that has been made to work with
+//! the most recent version of [`rlua`] and made to provide better error
+//! messages when things fail.
+//!
+//! [`Value`]: rlua::Value
+//! [`rlua_serde`]: https://crates.io/crates/rlua_serde
 
 #[cfg(test)]
 #[macro_use]
@@ -13,6 +20,13 @@ pub use self::de::LuaDeserializer as Deserializer;
 pub use self::error::Error;
 pub use self::ser::LuaSerializer as Serializer;
 
+/// Convert a rust value to a [`Value`].
+///
+/// This is a simple wrapper around `serialize` and [`Serializer`] that returns
+/// a [`rlua::Error`] so that it can be more easily used in [`rlua::ToLua`]
+/// implementations.
+///
+/// [`Value`]: rlua::Value
 pub fn to_value<'lua, T>(
   lua: rlua::Context<'lua>,
   value: &T,
@@ -23,6 +37,13 @@ where
   value.serialize(Serializer::new(lua)).map_err(From::from)
 }
 
+/// Convert a [`Value`] to a rust value.
+///
+/// This is a simple wrapper around `serialize` and [`Serializer`] that returns
+/// a [`rlua::Error`] so that it can be more easily used in [`rlua::FromLua`]
+/// implementations.
+///
+/// [`Value`]: rlua::Value
 pub fn from_value<'lua, 'de, T>(value: rlua::Value<'lua>) -> Result<T, rlua::Error>
 where
   T: serde::Deserialize<'de>,

--- a/utils/serde-rlua/src/lib.rs
+++ b/utils/serde-rlua/src/lib.rs
@@ -1,0 +1,31 @@
+//! This module is more or less a port of rlua_serde to work with the most
+//! recent rlua and also to fix some small nits around how it produces errors.
+
+#[cfg(test)]
+#[macro_use]
+extern crate serde;
+
+mod de;
+mod error;
+mod ser;
+
+pub use self::de::LuaDeserializer as Deserializer;
+pub use self::error::Error;
+pub use self::ser::LuaSerializer as Serializer;
+
+pub fn to_value<'lua, T>(
+  lua: rlua::Context<'lua>,
+  value: &T,
+) -> Result<rlua::Value<'lua>, rlua::Error>
+where
+  T: serde::Serialize,
+{
+  value.serialize(Serializer::new(lua)).map_err(From::from)
+}
+
+pub fn from_value<'lua, 'de, T>(value: rlua::Value<'lua>) -> Result<T, rlua::Error>
+where
+  T: serde::Deserialize<'de>,
+{
+  T::deserialize(Deserializer::new(value)).map_err(From::from)
+}

--- a/utils/serde-rlua/src/ser.rs
+++ b/utils/serde-rlua/src/ser.rs
@@ -4,6 +4,7 @@ use serde::ser::{self, Serialize, Serializer};
 
 use super::Error;
 
+/// Serializer for rlua `Value`s.
 pub struct LuaSerializer<'lua> {
   lua: Context<'lua>,
 }

--- a/utils/serde-rlua/src/ser.rs
+++ b/utils/serde-rlua/src/ser.rs
@@ -1,0 +1,539 @@
+use rlua::prelude::LuaString;
+use rlua::{Context, Table, Value};
+use serde::ser::{self, Serialize, Serializer};
+
+use super::Error;
+
+pub struct LuaSerializer<'lua> {
+  lua: Context<'lua>,
+}
+
+impl<'lua> LuaSerializer<'lua> {
+  pub fn new(lua: Context<'lua>) -> Self {
+    Self { lua }
+  }
+}
+
+impl<'lua> Serializer for LuaSerializer<'lua> {
+  type Ok = Value<'lua>;
+  type Error = Error;
+
+  type SerializeSeq = SerializeVec<'lua>;
+  type SerializeTuple = SerializeVec<'lua>;
+  type SerializeTupleStruct = SerializeVec<'lua>;
+  type SerializeTupleVariant = SerializeTupleVariant<'lua>;
+  type SerializeMap = SerializeMap<'lua>;
+  type SerializeStruct = SerializeMap<'lua>;
+  type SerializeStructVariant = SerializeStructVariant<'lua>;
+
+  #[inline]
+  fn serialize_bool(self, value: bool) -> Result<Self::Ok, Self::Error> {
+    Ok(Value::Boolean(value))
+  }
+
+  #[inline]
+  fn serialize_i8(self, value: i8) -> Result<Self::Ok, Self::Error> {
+    self.serialize_i64(i64::from(value))
+  }
+
+  #[inline]
+  fn serialize_i16(self, value: i16) -> Result<Self::Ok, Self::Error> {
+    self.serialize_i64(i64::from(value))
+  }
+
+  #[inline]
+  fn serialize_i32(self, value: i32) -> Result<Self::Ok, Self::Error> {
+    self.serialize_i64(i64::from(value))
+  }
+
+  #[inline]
+  fn serialize_i64(self, value: i64) -> Result<Self::Ok, Self::Error> {
+    Ok(Value::Integer(value))
+  }
+
+  #[inline]
+  fn serialize_u8(self, value: u8) -> Result<Self::Ok, Self::Error> {
+    self.serialize_i64(i64::from(value))
+  }
+
+  #[inline]
+  fn serialize_u16(self, value: u16) -> Result<Self::Ok, Self::Error> {
+    self.serialize_i64(i64::from(value))
+  }
+
+  #[inline]
+  fn serialize_u32(self, value: u32) -> Result<Self::Ok, Self::Error> {
+    self.serialize_i64(i64::from(value))
+  }
+
+  #[inline]
+  fn serialize_u64(self, value: u64) -> Result<Self::Ok, Self::Error> {
+    self.serialize_i64(value as i64)
+  }
+
+  #[inline]
+  fn serialize_f32(self, value: f32) -> Result<Self::Ok, Self::Error> {
+    self.serialize_f64(f64::from(value))
+  }
+
+  #[inline]
+  fn serialize_f64(self, value: f64) -> Result<Self::Ok, Self::Error> {
+    Ok(Value::Number(value))
+  }
+
+  #[inline]
+  fn serialize_char(self, value: char) -> Result<Self::Ok, Self::Error> {
+    let mut s = String::new();
+    s.push(value);
+    self.serialize_str(&s)
+  }
+
+  #[inline]
+  fn serialize_str(self, value: &str) -> Result<Self::Ok, Self::Error> {
+    Ok(Value::String(self.lua.create_string(value)?))
+  }
+
+  #[inline]
+  fn serialize_bytes(self, value: &[u8]) -> Result<Self::Ok, Self::Error> {
+    Ok(Value::Table(
+      self.lua.create_sequence_from(value.iter().cloned())?,
+    ))
+  }
+
+  #[inline]
+  fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+    Ok(Value::Nil)
+  }
+
+  #[inline]
+  fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+    self.serialize_unit()
+  }
+
+  #[inline]
+  fn serialize_unit_variant(
+    self,
+    _name: &'static str,
+    _variant_index: u32,
+    variant: &'static str,
+  ) -> Result<Self::Ok, Self::Error> {
+    self.serialize_str(variant)
+  }
+
+  #[inline]
+  fn serialize_newtype_struct<T>(
+    self,
+    _name: &'static str,
+    value: &T,
+  ) -> Result<Self::Ok, Self::Error>
+  where
+    T: ?Sized + serde::Serialize,
+  {
+    value.serialize(self)
+  }
+
+  fn serialize_newtype_variant<T>(
+    self,
+    _name: &'static str,
+    _variant_index: u32,
+    variant: &'static str,
+    value: &T,
+  ) -> Result<Self::Ok, Self::Error>
+  where
+    T: ?Sized + serde::Serialize,
+  {
+    let table = self.lua.create_table()?;
+    let variant = self.lua.create_string(variant)?;
+    let value = value.serialize(self)?;
+    table.set(variant, value)?;
+    Ok(Value::Table(table))
+  }
+
+  #[inline]
+  fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+    self.serialize_unit()
+  }
+
+  #[inline]
+  fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+  where
+    T: ?Sized + serde::Serialize,
+  {
+    value.serialize(self)
+  }
+
+  fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+    SerializeVec::new(self.lua)
+  }
+
+  fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+    self.serialize_seq(Some(len))
+  }
+
+  fn serialize_tuple_struct(
+    self,
+    _name: &'static str,
+    len: usize,
+  ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+    self.serialize_seq(Some(len))
+  }
+
+  fn serialize_tuple_variant(
+    self,
+    _name: &'static str,
+    _variant_index: u32,
+    variant: &'static str,
+    _len: usize,
+  ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+    SerializeTupleVariant::new(self.lua, variant)
+  }
+
+  fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+    SerializeMap::new(self.lua)
+  }
+
+  fn serialize_struct(
+    self,
+    _name: &'static str,
+    len: usize,
+  ) -> Result<Self::SerializeStruct, Self::Error> {
+    self.serialize_map(Some(len))
+  }
+
+  fn serialize_struct_variant(
+    self,
+    _name: &'static str,
+    _variant_index: u32,
+    variant: &'static str,
+    _len: usize,
+  ) -> Result<Self::SerializeStructVariant, Self::Error> {
+    SerializeStructVariant::new(self.lua, variant)
+  }
+}
+
+pub struct SerializeVec<'lua> {
+  lua: Context<'lua>,
+  table: Table<'lua>,
+  index: u64,
+}
+
+impl<'lua> SerializeVec<'lua> {
+  pub(crate) fn new(lua: Context<'lua>) -> Result<Self, Error> {
+    let table = lua.create_table()?;
+
+    Ok(Self {
+      lua,
+      table,
+      index: 1,
+    })
+  }
+}
+
+impl<'lua> ser::SerializeSeq for SerializeVec<'lua> {
+  type Ok = Value<'lua>;
+  type Error = Error;
+
+  fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+  where
+    T: Serialize,
+  {
+    let value = value.serialize(LuaSerializer::new(self.lua))?;
+    self.table.set(self.index, value)?;
+    self.index += 1;
+    Ok(())
+  }
+
+  fn end(self) -> Result<Self::Ok, Self::Error> {
+    Ok(Value::Table(self.table))
+  }
+}
+
+impl<'lua> ser::SerializeTuple for SerializeVec<'lua> {
+  type Ok = Value<'lua>;
+  type Error = Error;
+
+  fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+  where
+    T: Serialize,
+  {
+    ser::SerializeSeq::serialize_element(self, value)
+  }
+
+  fn end(self) -> Result<Self::Ok, Self::Error> {
+    ser::SerializeSeq::end(self)
+  }
+}
+
+impl<'lua> ser::SerializeTupleStruct for SerializeVec<'lua> {
+  type Ok = Value<'lua>;
+  type Error = Error;
+
+  fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+  where
+    T: Serialize,
+  {
+    ser::SerializeSeq::serialize_element(self, value)
+  }
+
+  fn end(self) -> Result<Self::Ok, Self::Error> {
+    ser::SerializeSeq::end(self)
+  }
+}
+
+pub struct SerializeMap<'lua> {
+  lua: Context<'lua>,
+  table: Table<'lua>,
+  next: Option<Value<'lua>>,
+}
+
+impl<'lua> SerializeMap<'lua> {
+  pub(crate) fn new(lua: Context<'lua>) -> Result<Self, Error> {
+    Ok(Self {
+      lua,
+      table: lua.create_table()?,
+      next: None,
+    })
+  }
+}
+
+impl<'lua> ser::SerializeMap for SerializeMap<'lua> {
+  type Ok = Value<'lua>;
+  type Error = Error;
+
+  fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
+  where
+    T: Serialize,
+  {
+    self.next = Some(key.serialize(LuaSerializer::new(self.lua))?);
+    Ok(())
+  }
+
+  fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+  where
+    T: Serialize,
+  {
+    let key = self
+      .next
+      .take()
+      .expect("serialize_value called before serialize_key");
+
+    self
+      .table
+      .set(key, value.serialize(LuaSerializer::new(self.lua))?)?;
+    Ok(())
+  }
+
+  fn serialize_entry<K: ?Sized, V: ?Sized>(&mut self, key: &K, value: &V) -> Result<(), Self::Error>
+  where
+    K: Serialize,
+    V: Serialize,
+  {
+    let key = key.serialize(LuaSerializer::new(self.lua))?;
+    let value = value.serialize(LuaSerializer::new(self.lua))?;
+
+    self.table.set(key, value)?;
+    Ok(())
+  }
+
+  fn end(self) -> Result<Self::Ok, Self::Error> {
+    Ok(Value::Table(self.table))
+  }
+}
+
+impl<'lua> ser::SerializeStruct for SerializeMap<'lua> {
+  type Ok = Value<'lua>;
+  type Error = Error;
+
+  fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+  where
+    T: Serialize,
+  {
+    ser::SerializeMap::serialize_entry(self, key, value)
+  }
+
+  fn end(self) -> Result<Self::Ok, Self::Error> {
+    ser::SerializeMap::end(self)
+  }
+}
+
+pub struct SerializeStructVariant<'lua> {
+  lua: Context<'lua>,
+  name: LuaString<'lua>,
+  table: Table<'lua>,
+}
+
+impl<'lua> SerializeStructVariant<'lua> {
+  pub(crate) fn new(lua: Context<'lua>, name: &str) -> Result<Self, Error> {
+    let table = lua.create_table()?;
+    let name = lua.create_string(name)?;
+
+    Ok(Self { lua, table, name })
+  }
+}
+
+impl<'lua> ser::SerializeStructVariant for SerializeStructVariant<'lua> {
+  type Ok = Value<'lua>;
+  type Error = Error;
+
+  fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+  where
+    T: Serialize,
+  {
+    self
+      .table
+      .set(key, value.serialize(LuaSerializer::new(self.lua))?)?;
+    Ok(())
+  }
+
+  fn end(self) -> Result<Self::Ok, Self::Error> {
+    let table = self.lua.create_table()?;
+    table.set(self.name, self.table)?;
+    Ok(Value::Table(table))
+  }
+}
+
+pub struct SerializeTupleVariant<'lua> {
+  lua: Context<'lua>,
+  name: LuaString<'lua>,
+  table: Table<'lua>,
+  index: u64,
+}
+
+impl<'lua> SerializeTupleVariant<'lua> {
+  pub(crate) fn new(lua: Context<'lua>, name: &str) -> Result<Self, Error> {
+    let table = lua.create_table()?;
+    let name = lua.create_string(name)?;
+
+    Ok(Self {
+      lua,
+      table,
+      name,
+      index: 1,
+    })
+  }
+}
+
+impl<'lua> ser::SerializeTupleVariant for SerializeTupleVariant<'lua> {
+  type Ok = Value<'lua>;
+  type Error = Error;
+
+  fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+  where
+    T: Serialize,
+  {
+    self
+      .table
+      .set(self.index, value.serialize(LuaSerializer::new(self.lua))?)?;
+    self.index += 1;
+    Ok(())
+  }
+
+  fn end(self) -> Result<Self::Ok, Self::Error> {
+    let table = self.lua.create_table()?;
+    table.set(self.name, self.table)?;
+    Ok(Value::Table(table))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use rlua::Lua;
+
+  use super::super::to_value;
+
+  #[test]
+  fn test_struct() {
+    #[derive(Serialize)]
+    struct Test {
+      int: u32,
+      seq: Vec<&'static str>,
+    }
+
+    let test = Test {
+      int: 1,
+      seq: vec!["a", "b"],
+    };
+
+    let lua = Lua::new();
+    lua
+      .context(|lua| {
+        let value = to_value(lua, &test).unwrap();
+        lua.globals().set("value", value).unwrap();
+        lua
+          .load(
+            r#"
+                assert(value["int"] == 1)
+                assert(value["seq"][1] == "a")
+                assert(value["seq"][2] == "b")
+            "#,
+          )
+          .exec()
+      })
+      .unwrap()
+  }
+
+  #[test]
+  fn test_num() {
+    #[derive(Serialize)]
+    enum E {
+      Unit,
+      Newtype(u32),
+      Tuple(u32, u32),
+      Struct { a: u32 },
+    }
+
+    let lua = Lua::new();
+
+    lua
+      .context(|lua| {
+        let u = E::Unit;
+        let value = to_value(lua, &u).unwrap();
+        lua.globals().set("value", value).unwrap();
+        lua
+          .load(
+            r#"
+                assert(value == "Unit")
+            "#,
+          )
+          .exec()
+          .unwrap();
+
+        let n = E::Newtype(1);
+        let value = to_value(lua, &n).unwrap();
+        lua.globals().set("value", value).unwrap();
+        lua
+          .load(
+            r#"
+                assert(value["Newtype"] == 1)
+            "#,
+          )
+          .exec()
+          .unwrap();
+
+        let t = E::Tuple(1, 2);
+        let value = to_value(lua, &t).unwrap();
+        lua.globals().set("value", value).unwrap();
+        lua
+          .load(
+            r#"
+                assert(value["Tuple"][1] == 1)
+                assert(value["Tuple"][2] == 2)
+            "#,
+          )
+          .exec()
+          .unwrap();
+
+        let s = E::Struct { a: 1 };
+        let value = to_value(lua, &s).unwrap();
+        lua.globals().set("value", value).unwrap();
+        lua
+          .load(
+            r#"
+                assert(value["Struct"]["a"] == 1)
+            "#,
+          )
+          .exec()
+      })
+      .unwrap();
+  }
+}


### PR DESCRIPTION
This is mostly a carbon-copy of the source code of the `rlua_serde` crate but updated to work with the most recent version of `rlua` and have better error messages when deserialization doesn't work.

None of this code is used just yet, but it will be used by future work in the config system.