### PR TITLE
Replace most uses of `MobType` with mob or missile prototypes

### DIFF
--- a/server-config/src/game.rs
+++ b/server-config/src/game.rs
@@ -3,7 +3,8 @@ use std::ops::{Deref, DerefMut};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-  GameConfigCommon, MissilePrototype, PlanePrototype, PrototypeRef, SpecialPrototype, StringRef,
+  GameConfigCommon, MissilePrototype, MobPrototype, PlanePrototype, PrototypeRef, SpecialPrototype,
+  StringRef,
 };
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -17,6 +18,7 @@ pub struct GamePrototype<'a, Ref: PrototypeRef<'a>> {
   pub planes: Vec<PlanePrototype<'a, Ref>>,
   pub missiles: Vec<MissilePrototype>,
   pub specials: Vec<SpecialPrototype<'a, Ref>>,
+  pub mobs: Vec<MobPrototype>,
 
   #[serde(flatten)]
   pub common: GameConfigCommon<'a, Ref>,
@@ -46,6 +48,11 @@ impl Default for GamePrototype<'_, StringRef> {
         SpecialPrototype::strafe(),
         SpecialPrototype::repel(),
         SpecialPrototype::stealth(),
+      ],
+      mobs: vec![
+        MobPrototype::inferno(),
+        MobPrototype::shield(),
+        MobPrototype::upgrade(),
       ],
       common: GameConfigCommon::default(),
     }

--- a/server-config/src/lib.rs
+++ b/server-config/src/lib.rs
@@ -8,6 +8,7 @@ mod config;
 mod error;
 mod game;
 mod missile;
+mod mob;
 mod plane;
 mod special;
 mod util;
@@ -24,6 +25,7 @@ pub(crate) use self::error::ValidationExt;
 pub use self::error::{Path, Segment, ValidationError};
 pub use self::game::GamePrototype;
 pub use self::missile::MissilePrototype;
+pub use self::mob::MobPrototype;
 pub use self::plane::PlanePrototype;
 pub use self::special::*;
 
@@ -39,6 +41,7 @@ pub trait PrototypeRef<'a>: Sealed {
   type MissileRef: Clone + Debug + 'a;
   type SpecialRef: Clone + Debug + 'a;
   type PlaneRef: Clone + Debug + 'a;
+  type MobRef: Clone + Debug + 'a;
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -54,10 +57,12 @@ impl<'a> PrototypeRef<'a> for StringRef {
   type MissileRef = Cow<'a, str>;
   type SpecialRef = Cow<'a, str>;
   type PlaneRef = Cow<'a, str>;
+  type MobRef = Cow<'a, str>;
 }
 
 impl<'a> PrototypeRef<'a> for PtrRef {
   type MissileRef = &'a MissilePrototype;
   type SpecialRef = &'a SpecialPrototype<'a, Self>;
   type PlaneRef = &'a PlanePrototype<'a, Self>;
+  type MobRef = &'a MobPrototype;
 }

--- a/server-config/src/mob.rs
+++ b/server-config/src/mob.rs
@@ -1,0 +1,60 @@
+use std::borrow::Cow;
+use std::time::Duration;
+
+use protocol::MobType;
+
+use crate::util::duration;
+use crate::ValidationError;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MobPrototype {
+  /// The name that will be used to this mob.
+  pub name: Cow<'static, str>,
+
+  /// The mob type that will be communicated to the client.
+  ///
+  /// This will determine the entity type that the client will show for the mob.
+  /// Setting it to the type of a missile is likely to break things.
+  pub server_type: MobType,
+
+  /// How long this mob will stick around before despawning.
+  #[serde(with = "duration")]
+  pub lifetime: Duration,
+}
+
+impl MobPrototype {
+  pub const fn inferno() -> Self {
+    Self {
+      name: Cow::Borrowed("inferno"),
+      server_type: MobType::Inferno,
+      lifetime: Duration::from_secs(60),
+    }
+  }
+
+  pub const fn shield() -> Self {
+    Self {
+      name: Cow::Borrowed("shield"),
+      server_type: MobType::Shield,
+      lifetime: Duration::from_secs(60),
+    }
+  }
+
+  pub const fn upgrade() -> Self {
+    Self {
+      name: Cow::Borrowed("upgrade"),
+      server_type: MobType::Upgrade,
+      lifetime: Duration::from_secs(60),
+    }
+  }
+}
+
+impl MobPrototype {
+  pub fn resolve(self) -> Result<Self, ValidationError> {
+    if self.name.is_empty() {
+      return Err(ValidationError::custom("name", "prototype had empty name"));
+    }
+
+    Ok(self)
+  }
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -12,6 +12,7 @@ pub mod config {
   pub type PlanePrototypeRef = &'static PlanePrototype<'static, PtrRef>;
   pub type MissilePrototypeRef = &'static MissilePrototype;
   pub type SpecialPrototypeRef = &'static SpecialPrototype<'static, PtrRef>;
+  pub type MobPrototypeRef = &'static MobPrototype;
 }
 
 pub extern crate hecs;

--- a/server/src/resource/config.rs
+++ b/server/src/resource/config.rs
@@ -132,6 +132,7 @@ pub struct Config {
   #[deprecated]
   pub planes: PlaneInfos,
   #[deserialize_over]
+  #[deprecated]
   pub mobs: MobInfos,
   #[deserialize_over]
   pub upgrades: UpgradeInfos,

--- a/server/src/system/handler/on_event_boost.rs
+++ b/server/src/system/handler/on_event_boost.rs
@@ -38,14 +38,17 @@ fn send_boost_packet(event: &EventBoost, game: &mut AirmashGame) {
 /// When boosting the player has negative regen. We need to set that.
 #[handler]
 fn set_player_energy_regen(event: &EventBoost, game: &mut AirmashGame) {
-  let (regen, plane) = match game.world.query_one_mut::<(&mut EnergyRegen, &PlanePrototypeRef)>(event.player) {
+  let (regen, plane) = match game
+    .world
+    .query_one_mut::<(&mut EnergyRegen, &PlanePrototypeRef)>(event.player)
+  {
     Ok(query) => query,
     Err(_) => return,
   };
 
   let boost = match plane.special.as_boost() {
     Some(boost) => boost,
-    None => return
+    None => return,
   };
 
   if event.boosting {

--- a/server/src/system/handler/on_missile_despawn.rs
+++ b/server/src/system/handler/on_missile_despawn.rs
@@ -1,6 +1,5 @@
-use airmash_protocol::MobType;
-
 use crate::component::*;
+use crate::config::MissilePrototypeRef;
 use crate::event::{MissileDespawn, MissileDespawnType};
 use crate::AirmashGame;
 
@@ -10,7 +9,7 @@ fn send_despawn_packet(event: &MissileDespawn, game: &mut AirmashGame) {
 
   let (&pos, &mob, ..) = match game
     .world
-    .query_one_mut::<(&Position, &MobType, &IsMissile)>(event.missile)
+    .query_one_mut::<(&Position, &MissilePrototypeRef, &IsMissile)>(event.missile)
   {
     Ok(query) => query,
     Err(_) => return,
@@ -28,7 +27,7 @@ fn send_despawn_packet(event: &MissileDespawn, game: &mut AirmashGame) {
       s::MobDespawnCoords {
         id: event.missile.id() as _,
         pos: pos.0,
-        ty: mob,
+        ty: mob.server_type,
       },
     );
   }

--- a/server/src/system/handler/on_missile_terrain_collision.rs
+++ b/server/src/system/handler/on_missile_terrain_collision.rs
@@ -1,6 +1,5 @@
-use airmash_protocol::MobType;
-
 use crate::component::*;
+use crate::config::MissilePrototypeRef;
 use crate::event::MissileTerrainCollision;
 use crate::AirmashGame;
 
@@ -10,7 +9,7 @@ fn send_despawn_packet(event: &MissileTerrainCollision, game: &mut AirmashGame) 
 
   let query = game
     .world
-    .query_one_mut::<(&MobType, &Position, &IsMissile)>(event.missile);
+    .query_one_mut::<(&MissilePrototypeRef, &Position, &IsMissile)>(event.missile);
   let (&mob, pos, ..) = match query {
     Ok(query) => query,
     Err(_) => return,
@@ -18,7 +17,7 @@ fn send_despawn_packet(event: &MissileTerrainCollision, game: &mut AirmashGame) 
 
   let packet = MobDespawnCoords {
     id: event.missile.id() as _,
-    ty: mob,
+    ty: mob.server_type,
     pos: pos.0,
   };
   game.send_to_visible(packet.pos, packet);

--- a/server/src/system/handler/on_mob_spawn.rs
+++ b/server/src/system/handler/on_mob_spawn.rs
@@ -1,6 +1,7 @@
 use airmash_protocol::server::MobUpdateStationary;
 
 use crate::component::*;
+use crate::config::MobPrototypeRef;
 use crate::event::MobSpawn;
 use crate::AirmashGame;
 
@@ -8,7 +9,7 @@ use crate::AirmashGame;
 fn send_packet(event: &MobSpawn, game: &mut AirmashGame) {
   let (&mob, &pos, _) = match game
     .world
-    .query_one_mut::<(&MobType, &Position, &IsMob)>(event.mob)
+    .query_one_mut::<(&MobPrototypeRef, &Position, &IsMob)>(event.mob)
   {
     Ok(query) => query,
     Err(_) => return,
@@ -18,7 +19,7 @@ fn send_packet(event: &MobSpawn, game: &mut AirmashGame) {
     pos.0,
     MobUpdateStationary {
       id: event.mob.id() as _,
-      ty: mob,
+      ty: mob.server_type,
       pos: pos.0,
     },
   );

--- a/server/src/system/handler/on_player_killed.rs
+++ b/server/src/system/handler/on_player_killed.rs
@@ -178,7 +178,6 @@ fn update_upgrades(event: &PlayerKilled, game: &mut AirmashGame) {
 #[handler(priority = crate::priority::HIGH)]
 fn drop_upgrade(event: &PlayerKilled, game: &mut AirmashGame) {
   let this_frame = game.this_frame();
-  let config = game.resources.read::<Config>();
   let game_config = game.resources.read::<GameConfig>();
 
   // Do nothing if we aren't supposed to be spawning upgrades.
@@ -200,17 +199,18 @@ fn drop_upgrade(event: &PlayerKilled, game: &mut AirmashGame) {
     return;
   }
 
-  let lifetime = config
-    .mobs
-    .upgrade
-    .lifetime
-    .unwrap_or(Duration::from_secs(60));
+  let gconfig = game.resources.read::<GameConfig>();
+  let mob = match gconfig.mobs.get("upgrade").copied() {
+    Some(mob) => mob,
+    // If there is no upgrade prototype then we don't drop upgrades
+    None => return,
+  };
   let prob = rand::random::<f32>();
 
-  drop(config);
+  drop(gconfig);
   drop(game_config);
 
   if total_upgrades > 0 || prob < consts::UPGRADE_DROP_PROBABILITY {
-    game.spawn_mob(MobType::Upgrade, pos.0, lifetime);
+    game.spawn_mob(mob.server_type, pos.0, mob.lifetime);
   }
 }

--- a/server/src/system/handler/on_player_mob_collision.rs
+++ b/server/src/system/handler/on_player_mob_collision.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use crate::component::*;
+use crate::config::MobPrototypeRef;
 use crate::event::{MobDespawn, MobDespawnType, PlayerMobCollision, PlayerPowerup, PowerupExpire};
 use crate::protocol::PowerupType;
 use crate::AirmashGame;
@@ -19,12 +20,15 @@ fn dispatch_despawn_event(event: &PlayerMobCollision, game: &mut AirmashGame) {
 
 #[handler(priority = crate::priority::HIGH)]
 fn update_player_upgrades(event: &PlayerMobCollision, game: &mut AirmashGame) {
-  let (&mob, _) = match game.world.query_one_mut::<(&MobType, &IsMob)>(event.mob) {
+  let (&mob, _) = match game
+    .world
+    .query_one_mut::<(&MobPrototypeRef, &IsMob)>(event.mob)
+  {
     Ok(query) => query,
     Err(_) => return,
   };
 
-  if mob != MobType::Upgrade {
+  if mob.server_type != MobType::Upgrade {
     return;
   }
 
@@ -44,12 +48,15 @@ fn update_player_upgrades(event: &PlayerMobCollision, game: &mut AirmashGame) {
 fn send_player_upgrade(event: &PlayerMobCollision, game: &mut AirmashGame) {
   use crate::protocol::server::ScoreUpdate;
 
-  let (&mob, _) = match game.world.query_one_mut::<(&MobType, &IsMob)>(event.mob) {
+  let (&mob, _) = match game
+    .world
+    .query_one_mut::<(&MobPrototypeRef, &IsMob)>(event.mob)
+  {
     Ok(query) => query,
     Err(_) => return,
   };
 
-  if mob != MobType::Upgrade {
+  if mob.server_type != MobType::Upgrade {
     return;
   }
 
@@ -79,12 +86,15 @@ fn send_player_upgrade(event: &PlayerMobCollision, game: &mut AirmashGame) {
 
 #[handler(priority = crate::priority::HIGH)]
 fn update_player_powerup(event: &PlayerMobCollision, game: &mut AirmashGame) {
-  let (&mob, _) = match game.world.query_one_mut::<(&MobType, &IsMob)>(event.mob) {
+  let (&mob, _) = match game
+    .world
+    .query_one_mut::<(&MobPrototypeRef, &IsMob)>(event.mob)
+  {
     Ok(query) => query,
     Err(_) => return,
   };
 
-  if !mob.is_powerup() {
+  if !mob.server_type.is_powerup() {
     return;
   }
 
@@ -104,7 +114,7 @@ fn update_player_powerup(event: &PlayerMobCollision, game: &mut AirmashGame) {
 
   game.dispatch(PlayerPowerup {
     player: event.player,
-    ty: match mob {
+    ty: match mob.server_type {
       MobType::Shield => PowerupType::Shield,
       MobType::Inferno => PowerupType::Inferno,
       _ => unreachable!(),

--- a/server/tests/behaviour/prowler.rs
+++ b/server/tests/behaviour/prowler.rs
@@ -7,7 +7,12 @@ use server::protocol::KeyCode;
 fn prowler_decloak_on_hit() {
   let (mut game, mut mock) = crate::utils::create_mock_server();
 
-  let &prowler = game.resources.read::<GameConfig>().planes.get("prowler").unwrap();
+  let &prowler = game
+    .resources
+    .read::<GameConfig>()
+    .planes
+    .get("prowler")
+    .unwrap();
 
   let mut client1 = mock.open();
   let mut client2 = mock.open();


### PR DESCRIPTION
This means that we can deprecated the most used fields of `Config` in preparation for replacing them with the structs defined in `server-config`.