### PR TITLE
Sequence `PLAYER_TYPE` messages before `PLAYER_RESPAWN` messages for plane change commands

### DIFF
--- a/server/src/system/handler/on_command.rs
+++ b/server/src/system/handler/on_command.rs
@@ -144,6 +144,10 @@ fn on_respawn_command(event: &PacketEvent<Command>, game: &mut AirmashGame) {
   drop(query);
   drop(gconfig);
 
+  // We need to make sure to update the plane type before respawning the player as
+  // otherwise using Q and E for strafing in a mohawk stops working. See issue
+  // #201 for a complete description of the issue and a root cause analysis behind
+  // why this is the solution.
   if old_proto.server_type != new_proto.server_type {
     game.dispatch(PlayerChangePlane {
       player: event.entity,

--- a/server/src/system/handler/on_command.rs
+++ b/server/src/system/handler/on_command.rs
@@ -144,17 +144,17 @@ fn on_respawn_command(event: &PacketEvent<Command>, game: &mut AirmashGame) {
   drop(query);
   drop(gconfig);
 
-  game.dispatch(PlayerRespawn {
-    player: event.entity,
-    alive: prev_alive,
-  });
-
   if old_proto.server_type != new_proto.server_type {
     game.dispatch(PlayerChangePlane {
       player: event.entity,
       old_proto,
     });
   }
+
+  game.dispatch(PlayerRespawn {
+    player: event.entity,
+    alive: prev_alive,
+  });
 }
 
 #[handler]

--- a/server/tests/behaviour/respawn.rs
+++ b/server/tests/behaviour/respawn.rs
@@ -25,3 +25,30 @@ fn respawn_as_mohawk() {
     }
   }
 }
+
+/// This test validates that issue #201 is actually fixed. If we send
+/// PLAYER_TYPE packets after PLAYER_RESPAWN packets then we'll find that the
+/// plane type used by the client for determining whether Q and E are enabled -
+/// and only for that - is one behind what it should be.
+#[test]
+fn player_type_before_player_respawn() {
+  let (mut game, mut mock) = TestGame::new();
+
+  let mut client = mock.open();
+  client.login("test", &mut game);
+
+  game.run_for(Duration::from_secs(2));
+
+  // Drain all previously sent packets
+  let _ = client.packets().count();
+  client.send_command("respawn", "3");
+  game.run_once();
+
+  // Verify that PLAYER_TYPE occurs before PLAYER_RESPAWN
+  assert!(client
+    .packets()
+    .any(|p| matches!(p, ServerPacket::PlayerType(_))));
+  assert!(client
+    .packets()
+    .any(|p| matches!(p, ServerPacket::PlayerRespawn(_))));
+}


### PR DESCRIPTION
Fixes #201. See that issue for a description of the root cause. This PR adds a fix as well as a test case to ensure it doesn't happen again.