### PR TITLE
Revert "Delete the `Config:admin_enabled` field in favour of `GameConfig::admin_enabled`"

### DIFF
--- a/ctf/tests/game-score-reset.rs
+++ b/ctf/tests/game-score-reset.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use airmash::component::*;
 use airmash::protocol::ServerPacket;
-use airmash::resource::GameConfig;
+use airmash::resource::Config;
 use airmash::test::*;
 use airmash_server_ctf::config::{FLAG_NO_REGRAB_TIME, RED_TEAM};
 use airmash_server_ctf::resource::GameScores;
@@ -15,7 +15,7 @@ fn scores_reset_on_game_win() {
   let mut conn = mock.open();
   let ent = conn.login("test", &mut game);
 
-  game.resources.write::<GameConfig>().admin_enabled = true;
+  game.resources.write::<Config>().admin_enabled = true;
   game.world.insert_one(ent, Team(RED_TEAM)).unwrap();
   game.run_once();
 

--- a/server/src/resource/config.rs
+++ b/server/src/resource/config.rs
@@ -137,6 +137,7 @@ pub struct Config {
   #[deserialize_over]
   pub upgrades: UpgradeInfos,
 
+  pub admin_enabled: bool,
   pub allow_spectate_while_moving: bool,
   #[serde(with = "duration")]
   pub spawn_shield_duration: Duration,
@@ -268,6 +269,7 @@ impl Default for Config {
       planes: Default::default(),
       mobs: Default::default(),
       upgrades: Default::default(),
+      admin_enabled: false,
       allow_spectate_while_moving: true,
       spawn_shield_duration: Duration::from_secs(2),
       shield_duration: Duration::from_secs(10),

--- a/server/src/resource/game_config.rs
+++ b/server/src/resource/game_config.rs
@@ -41,13 +41,6 @@ pub struct GameConfig {
   /// This is set to false by default.
   pub always_upgraded: bool,
 
-  /// Whether admin commands are enabled.
-  ///
-  /// This is set to false by default.
-  ///
-  /// TODO: This should be replaced with authenticating for admin commands.
-  pub admin_enabled: bool,
-
   pub inner: server_config::GameConfig,
 }
 
@@ -59,7 +52,6 @@ impl Default for GameConfig {
       allow_damage: true,
       spawn_upgrades: true,
       always_upgraded: false,
-      admin_enabled: false,
       inner: server_config::GameConfig::default(),
     }
   }

--- a/server/src/system/admin.rs
+++ b/server/src/system/admin.rs
@@ -6,7 +6,7 @@ use crate::event::PacketEvent;
 use crate::protocol::client::Command;
 use crate::protocol::server::CommandReply;
 use crate::protocol::CommandReplyType;
-use crate::resource::GameConfig;
+use crate::resource::Config;
 use crate::{AirmashGame, Vector2};
 
 #[handler]
@@ -80,7 +80,7 @@ fn teleport(event: &PacketEvent<Command>, game: &mut AirmashGame) {
     Ok(command)
   }
 
-  if !game.resources.read::<GameConfig>().admin_enabled {
+  if !game.resources.read::<Config>().admin_enabled {
     return;
   }
 

--- a/server/tests/behaviour/admin.rs
+++ b/server/tests/behaviour/admin.rs
@@ -1,5 +1,5 @@
 use airmash_server::component::Position;
-use airmash_server::resource::GameConfig;
+use airmash_server::resource::Config;
 use server::protocol::client as c;
 
 #[test]
@@ -14,7 +14,7 @@ fn admin_teleport() {
   let id = crate::utils::get_login_id(&mut client);
   let ent = game.find_entity_by_id(id).unwrap();
 
-  game.resources.write::<GameConfig>().admin_enabled = true;
+  game.resources.write::<Config>().admin_enabled = true;
 
   client.send(c::Command {
     com: "teleport".into(),


### PR DESCRIPTION
Reverts steamroller-airmash/airmash-server#208