### PR TITLE
Only run the verify-pass step on PR CI runs

### DIFF
--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -100,6 +100,7 @@ jobs:
           cargo run --release --color always --example validate-config -- configs/*.json
 
   verify-pass:
+    if: github.event_name == 'pull_request'
     name: verify-tests-pass
     needs: 
       - test


### PR DESCRIPTION
This should _hopefully_ help prevent some of the automerge issues that have cropped up around automerging happening without all the dependent CI checks passing.