### PR TITLE
Add a /uptime command to get server uptime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,7 @@ dependencies = [
  "fxhash",
  "hecs",
  "httparse",
+ "humantime",
  "itertools",
  "kdtree",
  "linkme",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -32,6 +32,7 @@ airmash-protocol = { version = "0.5.0", features = ["serde"] }
 server-macros = { path="../server-macros" }
 server-config = { path="../server-config" }
 kdtree = { path="../utils/kdtree" }
+humantime = "2.1.0"
 
 [dev-dependencies]
 approx = "0.5"

--- a/server/src/system/handler/on_command.rs
+++ b/server/src/system/handler/on_command.rs
@@ -333,3 +333,28 @@ fn on_upgrade_command(event: &PacketEvent<Command>, game: &mut AirmashGame) {
   game.force_update(event.entity);
   game.send_to(event.entity, packet);
 }
+
+#[handler]
+fn on_uptime_command(event: &PacketEvent<Command>, game: &mut AirmashGame) {
+  if event.packet.com != "uptime" {
+    return;
+  }
+
+  let start_time = game.start_time();
+  let this_frame = game.this_frame();
+  let uptime = this_frame.saturating_duration_since(start_time);
+
+  let message = if event.packet.data == "raw" {
+    uptime.as_secs().to_string()
+  } else {
+    humantime::format_duration(Duration::from_secs(uptime.as_secs())).to_string()
+  };
+
+  game.send_to(
+    event.entity,
+    s::CommandReply {
+      ty: airmash_protocol::CommandReplyType::ShowInConsole,
+      text: message.into(),
+    },
+  );
+}


### PR DESCRIPTION
As in title. Also supports an `/uptime raw` variant that just gives the raw time in seconds for use by scripts and bots.