### PR TITLE
Bump anymap version to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "anymap"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "cfg-if",
 ]

--- a/utils/anymap/Cargo.toml
+++ b/utils/anymap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anymap"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Dependabot's security alerts don't seem smart enough to figure out that we're using a local version of anymap so this will bump the version to something that doesn't trigger the security alert.