### PR TITLE
Remove unused flag

### DIFF
--- a/configs/default.json
+++ b/configs/default.json
@@ -270,7 +270,6 @@
       ]
     }
   },
-  "allow_spectate_while_moving": true,
   "spawn_shield_duration": 2.0,
   "shield_duration": 10.0,
   "inferno_duration": 10.0,

--- a/configs/no-moving-spectate.json
+++ b/configs/no-moving-spectate.json
@@ -1,3 +1,0 @@
-{
-  "allow_spectate_while_moving": false
-}

--- a/ctf/src/main.rs
+++ b/ctf/src/main.rs
@@ -54,10 +54,7 @@ fn main() {
 
     let mut de = serde_json::Deserializer::new(serde_json::de::IoRead::new(file));
 
-    let mut config = Config {
-      allow_spectate_while_moving: false,
-      ..Config::default()
-    };
+    let mut config = Config::default();
     config.deserialize_over(&mut de).unwrap();
 
     game.resources.insert(config);

--- a/ffa/src/main.rs
+++ b/ffa/src/main.rs
@@ -72,10 +72,7 @@ fn main() {
 
     let mut de = serde_json::Deserializer::new(serde_json::de::IoRead::new(file));
 
-    let mut config = Config {
-      allow_spectate_while_moving: false,
-      ..Config::default()
-    };
+    let mut config = Config::default();
     config.deserialize_over(&mut de).unwrap();
 
     game.resources.insert(config);

--- a/server/src/resource/config.rs
+++ b/server/src/resource/config.rs
@@ -137,7 +137,6 @@ pub struct Config {
   #[deserialize_over]
   pub upgrades: UpgradeInfos,
 
-  pub allow_spectate_while_moving: bool,
   #[serde(with = "duration")]
   pub spawn_shield_duration: Duration,
   #[serde(with = "duration")]
@@ -268,7 +267,6 @@ impl Default for Config {
       planes: Default::default(),
       mobs: Default::default(),
       upgrades: Default::default(),
-      allow_spectate_while_moving: true,
       spawn_shield_duration: Duration::from_secs(2),
       shield_duration: Duration::from_secs(10),
       inferno_duration: Duration::from_secs(10),


### PR DESCRIPTION
The `allow_spectate_while_moving` config option is unused so there's no point in keeping it around at the moment since it doesn't do what it's advertised to do anyway.