### PR TITLE
Make `StringRef` the default reference type for prototypes

### DIFF
--- a/server-config/src/game.rs
+++ b/server-config/src/game.rs
@@ -26,7 +26,7 @@ use crate::{
     Ref::MobRef: Deserialize<'de>,
   "
 ))]
-pub struct GamePrototype<'a, Ref: PrototypeRef<'a>> {
+pub struct GamePrototype<'a, Ref: PrototypeRef<'a> = StringRef> {
   pub planes: Vec<PlanePrototype<'a, Ref>>,
   pub missiles: Vec<MissilePrototype>,
   pub specials: Vec<SpecialPrototype<'a, Ref>>,

--- a/server-config/src/mob.rs
+++ b/server-config/src/mob.rs
@@ -26,7 +26,7 @@ use crate::{PrototypeRef, PtrRef, StringRef, ValidationError};
     Ref::MobRef: Deserialize<'de>,
   "
 ))]
-pub struct MobPrototype<'a, Ref: PrototypeRef<'a>> {
+pub struct MobPrototype<'a, Ref: PrototypeRef<'a> = StringRef> {
   /// The name that will be used to this mob.
   pub name: Cow<'static, str>,
 

--- a/server-config/src/plane.rs
+++ b/server-config/src/plane.rs
@@ -25,7 +25,7 @@ use crate::{MissilePrototype, PrototypeRef, PtrRef, SpecialPrototype, StringRef,
     Ref::MobRef: Deserialize<'de>,
   "
 ))]
-pub struct PlanePrototype<'a, Ref: PrototypeRef<'a>> {
+pub struct PlanePrototype<'a, Ref: PrototypeRef<'a> = StringRef> {
   /// The name with which to refer to this plane prototype. It must be unique
   /// among all plane prototypes.
   pub name: Cow<'static, str>,

--- a/server-config/src/special.rs
+++ b/server-config/src/special.rs
@@ -108,7 +108,7 @@ pub struct StealthPrototype {
     Ref::MobRef: Deserialize<'de>,
   "
 ))]
-pub struct SpecialPrototype<'a, Ref: PrototypeRef<'a>> {
+pub struct SpecialPrototype<'a, Ref: PrototypeRef<'a> = StringRef> {
   /// The name with which this special effect will be referred to.
   pub name: Cow<'static, str>,
   /// Parameters for the general class of special that is being configured.


### PR DESCRIPTION
Most of the time that these will be referred to directly it will be using `StringRef` so it makes sense to put this as the default.