### PR TITLE
Switch over to using `ultraviolet` as the vector math crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,16 +334,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "doc-cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4f3d1d3adb03db53727b1d60d42e247dbf4c8612f1afff5efb52ad1bd1c264"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
-]
-
-[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,8 +576,8 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73fd9dc7072de7168cbdaba9125e8f742cd3a965aa12bde994b4611a174488d8"
 dependencies = [
- "proc-macro2 1.0.40",
- "quote 1.0.20",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -647,8 +637,8 @@ version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b5bc45b761bcf1b5e6e6c4128cd93b84c218721a8d9b894aa0aff4ed180174c"
 dependencies = [
- "proc-macro2 1.0.40",
- "quote 1.0.20",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -703,8 +693,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
 dependencies = [
- "proc-macro2 1.0.40",
- "quote 1.0.20",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -774,15 +764,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
-name = "ordered-float"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "os_str_bytes"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,8 +823,8 @@ dependencies = [
  "phf_generator",
  "phf_shared",
  "proc-macro-hack",
- "proc-macro2 1.0.40",
- "quote 1.0.20",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -898,15 +879,6 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
@@ -916,20 +888,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
- "proc-macro2 1.0.40",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -1062,8 +1025,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa16ae143220a3e28e74f2dba438578cbe6c8419058698654b0a54560125c7b1"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.40",
- "quote 1.0.20",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -1085,23 +1048,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
 dependencies = [
- "proc-macro2 1.0.40",
- "quote 1.0.20",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -1131,12 +1084,9 @@ version = "0.1.0"
 dependencies = [
  "airmash-protocol",
  "anyhow",
- "doc-cfg",
- "nalgebra",
  "rlua",
  "serde",
  "serde-rlua",
- "serde-value",
  "serde_json",
  "serde_path_to_error",
  "ultraviolet",
@@ -1147,8 +1097,8 @@ name = "server-macros"
 version = "0.1.0"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.40",
- "quote 1.0.20",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -1256,8 +1206,8 @@ version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
- "proc-macro2 1.0.40",
- "quote 1.0.20",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -1306,8 +1256,8 @@ version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
- "proc-macro2 1.0.40",
- "quote 1.0.20",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -1350,8 +1300,8 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
- "proc-macro2 1.0.40",
- "quote 1.0.20",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -1447,12 +1397,6 @@ name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "url"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,6 @@ dependencies = [
  "htmlescape",
  "lazy_static",
  "log",
- "phf",
  "rand",
  "serde-deserialize-over",
  "serde_json",
@@ -718,50 +717,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
-name = "phf"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
-dependencies = [
- "phf_macros",
- "phf_shared",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,12 +749,6 @@ dependencies = [
  "thiserror",
  "toml",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
@@ -1030,12 +979,6 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
-
-[[package]]
-name = "siphasher"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-tungstenite",
+ "ultraviolet",
  "uuid",
 ]
 
@@ -1138,6 +1139,7 @@ dependencies = [
  "serde-value",
  "serde_json",
  "serde_path_to_error",
+ "ultraviolet",
 ]
 
 [[package]]
@@ -1398,6 +1400,17 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "ultraviolet"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf2728f3858937f50df6d92b741f53ef8fd5b5ae23b03b73fb9ac891e980df3b"
+dependencies = [
+ "mint",
+ "serde",
+ "wide",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,6 @@ dependencies = [
  "crossbeam-channel",
  "futures-task",
  "futures-util",
- "fxhash",
  "hecs",
  "httparse",
  "humantime",
@@ -396,15 +395,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,6 @@ dependencies = [
  "log",
  "miette",
  "mint",
- "nalgebra",
  "rand",
  "serde",
  "serde-deserialize-over",
@@ -597,15 +596,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
-dependencies = [
- "rawpointer",
-]
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,66 +660,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nalgebra"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a89248335f688e4bd994e6d030fd7e185eb41769b8c435395075425e100ac6"
-dependencies = [
- "approx",
- "matrixmultiply",
- "mint",
- "nalgebra-macros",
- "num-complex",
- "num-rational",
- "num-traits",
- "serde",
- "simba",
- "typenum",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fbc387afefefd5e9e39493299f3069e14a140dd34dc19b4c1c1a8fddb6a790"
-dependencies = [
- "num-traits",
- "serde",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,12 +704,6 @@ name = "owo-colors"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "decf7381921fea4dcb2549c5667eda59b3ec297ab7e2b5fc33eac69d2e7da87b"
-
-[[package]]
-name = "paste"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
 name = "pdqselect"
@@ -924,12 +848,6 @@ checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "regex"
@@ -1111,19 +1029,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
-]
-
-[[package]]
-name = "simba"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a2609e876d4f77f6ab7ff5254fc39b4f1927ba8e6db3d18be7c32534d3725e"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "paste",
- "wide",
 ]
 
 [[package]]

--- a/ctf/Cargo.toml
+++ b/ctf/Cargo.toml
@@ -20,18 +20,8 @@ bstr = "0.2"
 
 lazy_static = "1.4"
 smallvec = "1.6"
-phf = { version="0.10", features=["macros"] }
 
 [dependencies.airmash]
 path="../server"
 package = "airmash-server"
 features = ["mt-network"]
-
-# [dependencies.sentry]
-# optional = true
-# version = "*"
-
-# [dependencies.airmash-server]
-# path = '../server'
-# # Enable looking for X-Forwarded-For within the request
-# features = [ "proxied" ]

--- a/ctf/src/config.rs
+++ b/ctf/src/config.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use airmash::util::NalgebraExt;
 use airmash::Vector2;
 
 pub const BLUE_TEAM: u16 = 1;

--- a/ctf/src/config.rs
+++ b/ctf/src/config.rs
@@ -7,14 +7,14 @@ pub const RED_TEAM: u16 = 2;
 
 pub const FLAG_RADIUS: f32 = 100.0;
 
-pub const FLAG_HOME_POS: [Vector2<f32>; 2] = [
+pub const FLAG_HOME_POS: [Vector2; 2] = [
   // Blue team
   Vector2::new(-9670.0, -1470.0),
   // Red team
   Vector2::new(8600.0, -940.0),
 ];
 
-pub const TEAM_RESPAWN_POS: [Vector2<f32>; 2] = [
+pub const TEAM_RESPAWN_POS: [Vector2; 2] = [
   Vector2::new(-8878.0, -2971.0),
   Vector2::new(7818.0, -2930.0),
 ];
@@ -30,13 +30,13 @@ pub const FLAG_CAP_BOUNTY_BASE: u32 = 100;
 /// if they were the only ones on the server.
 pub const GAME_WIN_BOUNTY_BASE: u32 = 100;
 
-pub fn flag_return_pos(team: u16) -> Vector2<f32> {
+pub fn flag_return_pos(team: u16) -> Vector2 {
   FLAG_HOME_POS[(2 - team) as usize]
 }
-pub fn flag_home_pos(team: u16) -> Vector2<f32> {
+pub fn flag_home_pos(team: u16) -> Vector2 {
   FLAG_HOME_POS[(team - 1) as usize]
 }
-pub fn team_respawn_pos(team: u16) -> Vector2<f32> {
+pub fn team_respawn_pos(team: u16) -> Vector2 {
   TEAM_RESPAWN_POS
     .get((team - 1) as usize)
     .copied()

--- a/ctf/src/systems/on_frame.rs
+++ b/ctf/src/systems/on_frame.rs
@@ -1,6 +1,7 @@
 use airmash::component::*;
 use airmash::event::Frame;
 use airmash::resource::collision::LayerSpec;
+use airmash::util::NalgebraExt;
 use airmash::AirmashGame;
 use smallvec::SmallVec;
 

--- a/ffa/src/systems.rs
+++ b/ffa/src/systems.rs
@@ -3,11 +3,11 @@ use server::event::{PlayerJoin, PlayerRespawn};
 use server::resource::collision::{LayerSpec, Terrain};
 use server::{AirmashGame, Vector2};
 
-const SPAWN_TOP_RIGHT: Vector2<f32> = Vector2::new(-1325.0, -4330.0);
-const SPAWN_SIZE: Vector2<f32> = Vector2::new(3500.0, 2500.0);
+const SPAWN_TOP_RIGHT: Vector2 = Vector2::new(-1325.0, -4330.0);
+const SPAWN_SIZE: Vector2 = Vector2::new(3500.0, 2500.0);
 const SPAWN_RADIUS: f32 = 100.0;
 
-pub fn select_spawn_position(game: &AirmashGame) -> Vector2<f32> {
+pub fn select_spawn_position(game: &AirmashGame) -> Vector2 {
   let terrain = game.resources.read::<Terrain>();
 
   loop {

--- a/server-config/Cargo.toml
+++ b/server-config/Cargo.toml
@@ -8,11 +8,7 @@ script = [ "rlua", "serde-rlua" ]
 
 [dependencies]
 serde = { version = "1.0", features = [ "derive" ] }
-serde-value = "0.7"
-serde_path_to_error = "0.1.7"
-nalgebra = { version = "0.31", features = ["serde-serialize"] }
 ultraviolet = { version = "0.9", features = ["serde", "mint"] }
-doc-cfg = "0.1"
 
 rlua = { version = "0.19", optional = true }
 serde-rlua = { path = "../utils/serde-rlua", optional = true }
@@ -24,6 +20,7 @@ features = [ "serde" ]
 
 [dev-dependencies]
 serde_json = "1.0"
+serde_path_to_error = "0.1.7"
 anyhow = "1.0"
 
 [[example]]

--- a/server-config/Cargo.toml
+++ b/server-config/Cargo.toml
@@ -11,6 +11,7 @@ serde = { version = "1.0", features = [ "derive" ] }
 serde-value = "0.7"
 serde_path_to_error = "0.1.7"
 nalgebra = { version = "0.31", features = ["serde-serialize"] }
+ultraviolet = { version = "0.9", features = ["serde", "mint"] }
 doc-cfg = "0.1"
 
 rlua = { version = "0.19", optional = true }

--- a/server-config/src/lib.rs
+++ b/server-config/src/lib.rs
@@ -29,6 +29,8 @@ pub use self::plane::PlanePrototype;
 pub use self::powerup::PowerupPrototype;
 pub use self::special::*;
 
+pub type Vector2 = nalgebra::Vector2<f32>;
+
 mod sealed {
   pub trait Sealed {}
 }

--- a/server-config/src/lib.rs
+++ b/server-config/src/lib.rs
@@ -29,7 +29,7 @@ pub use self::plane::PlanePrototype;
 pub use self::powerup::PowerupPrototype;
 pub use self::special::*;
 
-pub type Vector2 = nalgebra::Vector2<f32>;
+pub type Vector2 = ultraviolet::Vec2;
 
 mod sealed {
   pub trait Sealed {}

--- a/server-config/src/plane.rs
+++ b/server-config/src/plane.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use protocol::PlaneType;
 use serde::{Deserialize, Serialize};
 
-use crate::util::duration;
+use crate::util::{duration, vector};
 use crate::{
   MissilePrototype, PrototypeRef, PtrRef, SpecialPrototype, StringRef, ValidationError, Vector2,
 };
@@ -58,6 +58,7 @@ pub struct PlanePrototype<'a, Ref: PrototypeRef<'a> = StringRef> {
   /// The offset at which the missile will be fired from the plane. X
   /// corresponds to the distance in front of the plane while Y gives the
   /// distance sideways from the plane and will alternate sides with each shot.
+  #[serde(with = "vector")]
   pub missile_offset: Vector2,
 
   /// The energy that it takes the plane to fire a single shot.
@@ -99,6 +100,7 @@ pub struct PlanePrototype<'a, Ref: PrototypeRef<'a> = StringRef> {
   pub brake: f32,
 
   /// Displacement of the outside missile when the plane fires with an inferno.
+  #[serde(with = "vector")]
   pub inferno_offset: Vector2,
   /// Angle of the outside missile when the plane fires with an inferno.
   pub inferno_angle: f32,

--- a/server-config/src/plane.rs
+++ b/server-config/src/plane.rs
@@ -1,12 +1,13 @@
 use std::borrow::Cow;
 use std::time::Duration;
 
-use nalgebra::Vector2;
 use protocol::PlaneType;
 use serde::{Deserialize, Serialize};
 
 use crate::util::duration;
-use crate::{MissilePrototype, PrototypeRef, PtrRef, SpecialPrototype, StringRef, ValidationError};
+use crate::{
+  MissilePrototype, PrototypeRef, PtrRef, SpecialPrototype, StringRef, ValidationError, Vector2,
+};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -57,7 +58,7 @@ pub struct PlanePrototype<'a, Ref: PrototypeRef<'a> = StringRef> {
   /// The offset at which the missile will be fired from the plane. X
   /// corresponds to the distance in front of the plane while Y gives the
   /// distance sideways from the plane and will alternate sides with each shot.
-  pub missile_offset: Vector2<f32>,
+  pub missile_offset: Vector2,
 
   /// The energy that it takes the plane to fire a single shot.
   pub fire_energy: f32,
@@ -98,7 +99,7 @@ pub struct PlanePrototype<'a, Ref: PrototypeRef<'a> = StringRef> {
   pub brake: f32,
 
   /// Displacement of the outside missile when the plane fires with an inferno.
-  pub inferno_offset: Vector2<f32>,
+  pub inferno_offset: Vector2,
   /// Angle of the outside missile when the plane fires with an inferno.
   pub inferno_angle: f32,
 }

--- a/server-config/src/util.rs
+++ b/server-config/src/util.rs
@@ -35,6 +35,19 @@ pub(crate) mod option_duration {
   }
 }
 
+pub(crate) mod vector {
+  use crate::Vector2;
+  use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+  pub(crate) fn serialize<S: Serializer>(v: &Vector2, ser: S) -> Result<S::Ok, S::Error> {
+    [v.x, v.y].serialize(ser)
+  }
+
+  pub(crate) fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<Vector2, D::Error> {
+    <[f32; 2]>::deserialize(de).map(From::from)
+  }
+}
+
 /// Wrapper type around [`ManuallyDrop`] which drops the contained value unless
 /// it is explicitly prevented from doing so.
 pub(crate) struct MaybeDrop<T> {

--- a/server-config/src/util.rs
+++ b/server-config/src/util.rs
@@ -36,8 +36,9 @@ pub(crate) mod option_duration {
 }
 
 pub(crate) mod vector {
-  use crate::Vector2;
   use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+  use crate::Vector2;
 
   pub(crate) fn serialize<S: Serializer>(v: &Vector2, ser: S) -> Result<S::Ok, S::Error> {
     [v.x, v.y].serialize(ser)

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -8,7 +8,6 @@ mt-network = []
 
 [dependencies]
 hecs = "0.7.7"
-nalgebra = { version = "0.31.0", features = ["serde-serialize", "convert-mint"] }
 linkme = "0.2.6"
 log = "0.4"
 crossbeam-channel = "0.5"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,7 +17,6 @@ uuid = { version = "1.1", features = ["v4"] }
 smallvec = "1.6"
 itertools = "0.10"
 slab = "0.4"
-fxhash = "0.2"
 httparse = "1.6.0"
 humantime = "2.1.0"
 mint = "0.5"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -22,6 +22,7 @@ fxhash = "0.2"
 httparse = "1.6.0"
 humantime = "2.1.0"
 mint = "0.5"
+ultraviolet = { version = "0.9", features = ["serde", "mint"] }
 
 tokio = { version="1.0", features=["rt", "sync", "io-util", "macros", "time", "rt-multi-thread"] }
 tokio-tungstenite = "0.17.1"

--- a/server/src/component/mod.rs
+++ b/server/src/component/mod.rs
@@ -17,13 +17,13 @@ pub use crate::protocol::{FlagCode, MobType, PlaneType, PowerupType};
 
 def_wrappers! {
   /// The position of an entity.
-  pub type Position = Vector2<f32>;
+  pub type Position = Vector2;
 
   /// The velocity of an entity.
-  pub type Velocity = Vector2<f32>;
+  pub type Velocity = Vector2;
 
   /// The acceleration of an entity.
-  pub type Accel = Vector2<f32>;
+  pub type Accel = Vector2;
 
   /// The rotation of an entity.
   pub type Rotation = crate::protocol::Rotation;
@@ -187,7 +187,7 @@ pub struct PrevUpgrades(pub Upgrades);
 /// lifetime.
 #[derive(Copy, Clone, Debug)]
 pub struct MissileTrajectory {
-  pub start: Vector2<f32>,
+  pub start: Vector2,
   pub maxdist: f32,
 }
 

--- a/server/src/consts/hitcircles.rs
+++ b/server/src/consts/hitcircles.rs
@@ -1,7 +1,7 @@
 use crate::protocol::PlaneType;
 use crate::Vector2;
 
-type HitCircle = (Vector2<f32>, f32);
+type HitCircle = (Vector2, f32);
 
 macro_rules! hit_circle {
   ($x:expr, $y:expr, $r:expr) => {

--- a/server/src/consts/mod.rs
+++ b/server/src/consts/mod.rs
@@ -2,11 +2,9 @@
 
 use std::time::Duration;
 
-use nalgebra::vector;
-
 use crate::config::MissilePrototypeRef;
 use crate::protocol::*;
-use crate::FireMissileInfo;
+use crate::{FireMissileInfo, Vector2};
 
 mod hitcircles;
 mod terrain;
@@ -41,17 +39,17 @@ pub const TORNADO_SPECIAL_ENERGY: Energy = 0.9;
 pub fn tornado_missile_details(proto: MissilePrototypeRef) -> [FireMissileInfo; 3] {
   [
     FireMissileInfo {
-      pos_offset: vector![0.0, 40.1],
+      pos_offset: Vector2::new(0.0, 40.1),
       rot_offset: 0.0,
       proto,
     },
     FireMissileInfo {
-      pos_offset: vector![15.0, 9.6],
+      pos_offset: Vector2::new(15.0, 9.6),
       rot_offset: -0.05,
       proto,
     },
     FireMissileInfo {
-      pos_offset: vector![-15.0, 9.6],
+      pos_offset: Vector2::new(-15.0, 9.6),
       rot_offset: 0.05,
       proto,
     },
@@ -60,27 +58,27 @@ pub fn tornado_missile_details(proto: MissilePrototypeRef) -> [FireMissileInfo; 
 pub fn tornado_inferno_missile_details(proto: MissilePrototypeRef) -> [FireMissileInfo; 5] {
   [
     FireMissileInfo {
-      pos_offset: vector![0.0, 40.1],
+      pos_offset: Vector2::new(0.0, 40.1),
       rot_offset: 0.0,
       proto,
     },
     FireMissileInfo {
-      pos_offset: vector![30.0, 15.0],
+      pos_offset: Vector2::new(30.0, 15.0),
       rot_offset: -0.1,
       proto,
     },
     FireMissileInfo {
-      pos_offset: vector![20.0, 25.0],
+      pos_offset: Vector2::new(20.0, 25.0),
       rot_offset: -0.05,
       proto,
     },
     FireMissileInfo {
-      pos_offset: vector![-20.0, 25.0],
+      pos_offset: Vector2::new(-20.0, 25.0),
       rot_offset: 0.05,
       proto,
     },
     FireMissileInfo {
-      pos_offset: vector![-30.0, 15.0],
+      pos_offset: Vector2::new(-30.0, 15.0),
       rot_offset: 0.1,
       proto,
     },

--- a/server/src/defaults.rs
+++ b/server/src/defaults.rs
@@ -12,6 +12,7 @@ use crate::component::*;
 use crate::config::PlanePrototypeRef;
 use crate::protocol::client::Login;
 use crate::protocol::FlagCode;
+use crate::util::NalgebraExt;
 use crate::Vector2;
 
 /// Build a player

--- a/server/src/event/mod.rs
+++ b/server/src/event/mod.rs
@@ -218,7 +218,7 @@ pub struct EventBounce {
   ///
   /// The current direction of the player is contained within the
   /// [`Velocity`](crate::component::Velocity) component.
-  pub old_vel: Vector2<f32>,
+  pub old_vel: Vector2,
 }
 
 /// A player's powerup has expired.

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -47,9 +47,9 @@ pub mod system;
 pub mod util;
 
 pub use hecs::Entity;
-pub use nalgebra::Vector2;
 pub use server_macros::handler;
 
+pub use self::config::Vector2;
 pub use self::dispatch::{Event, EventDispatcher, EventHandler};
 pub use self::task::{GameRef, TaskScheduler};
 pub use self::world::{AirmashGame, Resources};

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -17,7 +17,6 @@ pub mod config {
 }
 
 pub extern crate hecs;
-pub extern crate nalgebra;
 
 #[macro_use]
 extern crate serde;

--- a/server/src/resource/collision.rs
+++ b/server/src/resource/collision.rs
@@ -25,7 +25,7 @@ def_wrappers! {
 
 #[derive(Copy, Clone, Debug)]
 pub struct Entry {
-  pub pos: Vector2<f32>,
+  pub pos: Vector2,
   pub radius: f32,
   pub entity: Entity,
   pub layer: u16,
@@ -68,7 +68,7 @@ impl SpatialTree {
     self.tree.rebuild_from(&mut entries);
   }
 
-  pub fn contains(&self, pos: Vector2<f32>, rad: f32, layer: LayerSpec) -> bool {
+  pub fn contains(&self, pos: Vector2, rad: f32, layer: LayerSpec) -> bool {
     let pos = [pos.x, pos.y];
 
     match layer {
@@ -92,7 +92,7 @@ impl SpatialTree {
   /// [`query`]: self::SpatialTree::query
   pub fn query_pos<V: Extend<Entity>>(
     &self,
-    pos: Vector2<f32>,
+    pos: Vector2,
     rad: f32,
     layer: LayerSpec,
     out: &mut V,
@@ -115,13 +115,7 @@ impl SpatialTree {
   /// defined by `pos` and `rad`.
   ///
   /// This result is then filtered by the `LayerSpec` given in `layer`.
-  pub fn query<V: Extend<Entity>>(
-    &self,
-    pos: Vector2<f32>,
-    rad: f32,
-    layer: LayerSpec,
-    out: &mut V,
-  ) {
+  pub fn query<V: Extend<Entity>>(&self, pos: Vector2, rad: f32, layer: LayerSpec, out: &mut V) {
     let base = self.tree.within([pos.x, pos.y], rad);
 
     match layer {

--- a/server/src/resource/collision.rs
+++ b/server/src/resource/collision.rs
@@ -3,6 +3,7 @@
 use hecs::Entity;
 use kdtree::{KdTree, Node};
 
+use crate::util::NalgebraExt;
 use crate::Vector2;
 
 def_wrappers! {

--- a/server/src/resource/collision.rs
+++ b/server/src/resource/collision.rs
@@ -2,7 +2,6 @@
 
 use hecs::Entity;
 use kdtree::{KdTree, Node};
-use nalgebra::vector;
 
 use crate::Vector2;
 
@@ -146,7 +145,7 @@ impl Default for Terrain {
     for [x, y, r] in TERRAIN {
       entries.push(Entry {
         entity: Entity::from_bits(1 << 32).unwrap(),
-        pos: vector![x as f32, y as f32],
+        pos: Vector2::new(x as f32, y as f32),
         radius: r as f32,
         layer: 0,
       });

--- a/server/src/resource/config.rs
+++ b/server/src/resource/config.rs
@@ -45,6 +45,7 @@ pub struct PlaneInfo {
   // Offset of missile relative to the plane when fired.
   //
   // The horizontal (Y) offset will alternate sides with every shot.
+  #[serde(with = "vector")]
   pub missile_offset: Vector2,
 
   // Angle and displacement of the other two missiles when inferno firing

--- a/server/src/resource/config.rs
+++ b/server/src/resource/config.rs
@@ -3,7 +3,6 @@
 use std::ops::Index;
 use std::time::Duration;
 
-use nalgebra::vector;
 use serde_deserialize_over::DeserializeOver;
 
 use crate::protocol::{
@@ -306,7 +305,7 @@ mod plane_defaults {
       fire_energy: 0.6,
 
       missile_type: MobType::PredatorMissile,
-      missile_offset: vector![35.0, 0.0],
+      missile_offset: Vector2::new(35.0, 0.0),
 
       missile_inferno_angle: 0.05,
       missile_inferno_offset_x: 18.0,
@@ -335,7 +334,7 @@ mod plane_defaults {
       fire_energy: 0.9,
 
       missile_type: MobType::GoliathMissile,
-      missile_offset: vector![35.0, 0.0],
+      missile_offset: Vector2::new(35.0, 0.0),
 
       missile_inferno_angle: 0.04,
       missile_inferno_offset_x: 30.0,
@@ -365,7 +364,7 @@ mod plane_defaults {
 
       missile_type: MobType::MohawkMissile,
       // This will have to be a special case
-      missile_offset: vector![10.0, 15.0],
+      missile_offset: Vector2::new(10.0, 15.0),
 
       missile_inferno_angle: 0.1,
       missile_inferno_offset_x: 0.0,
@@ -394,7 +393,7 @@ mod plane_defaults {
       fire_energy: 0.5,
 
       missile_type: MobType::TornadoSingleMissile,
-      missile_offset: vector![40.0, 0.0],
+      missile_offset: Vector2::new(40.0, 0.0),
 
       missile_inferno_angle: 0.05,
       missile_inferno_offset_x: 15.1,
@@ -423,7 +422,7 @@ mod plane_defaults {
       fire_energy: 0.75,
 
       missile_type: MobType::ProwlerMissile,
-      missile_offset: vector![35.0, 0.0],
+      missile_offset: Vector2::new(35.0, 0.0),
 
       missile_inferno_angle: 0.05,
       missile_inferno_offset_x: 18.0,

--- a/server/src/resource/config.rs
+++ b/server/src/resource/config.rs
@@ -46,7 +46,7 @@ pub struct PlaneInfo {
   // Offset of missile relative to the plane when fired.
   //
   // The horizontal (Y) offset will alternate sides with every shot.
-  pub missile_offset: Vector2<Distance>,
+  pub missile_offset: Vector2,
 
   // Angle and displacement of the other two missiles when inferno firing
   // (assuming symmetry around central missile)

--- a/server/src/system/admin.rs
+++ b/server/src/system/admin.rs
@@ -18,7 +18,7 @@ fn teleport(event: &PacketEvent<Command>, game: &mut AirmashGame) {
     pub pos_y: f32,
   }
 
-  fn named_positions(s: &[u8]) -> Option<Vector2<f32>> {
+  fn named_positions(s: &[u8]) -> Option<Vector2> {
     let (x, y) = match s {
       b"blue-flag" => (-9670.0, -1470.0),
       b"red-flag" => (8600.0, -940.0),

--- a/server/src/system/collision.rs
+++ b/server/src/system/collision.rs
@@ -11,6 +11,7 @@ use crate::event::{
   EventBounce, MissileTerrainCollision, PlayerMissileCollision, PlayerMobCollision,
 };
 use crate::resource::collision::*;
+use crate::util::NalgebraExt;
 use crate::AirmashGame;
 
 struct FrameId(usize);
@@ -170,7 +171,7 @@ fn collide_player_terrain(game: &mut AirmashGame) {
     };
 
     let rel = collision.0.pos - collision.1.pos;
-    let newvel = rel.normalize() * vel.norm().max(1.0);
+    let newvel = rel.normalized() * vel.norm().max(1.0);
     let old_vel = std::mem::replace(&mut vel.0, newvel);
 
     events.push(EventBounce {

--- a/server/src/system/despawn.rs
+++ b/server/src/system/despawn.rs
@@ -2,6 +2,7 @@ use smallvec::SmallVec;
 
 use crate::component::{IsMissile, *};
 use crate::event::{MissileDespawn, MissileDespawnType, MobDespawn, MobDespawnType};
+use crate::util::NalgebraExt;
 use crate::AirmashGame;
 
 pub fn update(game: &mut AirmashGame) {

--- a/server/src/system/handler/on_player_fire.rs
+++ b/server/src/system/handler/on_player_fire.rs
@@ -30,7 +30,7 @@ pub fn send_player_fire(event: &PlayerFire, game: &mut AirmashGame) {
         pos: pos.into(),
         speed: vel.into(),
         ty: mob.server_type,
-        accel: (vel.normalize() * mob.accel).into(),
+        accel: (vel.normalized() * mob.accel).into(),
         max_speed: mob.max_speed,
       });
     } else {

--- a/server/src/system/handler/on_player_killed.rs
+++ b/server/src/system/handler/on_player_killed.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use crate::component::*;
 use crate::event::{PlayerKilled, PlayerRespawn};
 use crate::resource::{GameConfig, TaskScheduler, ThisFrame};
+use crate::util::NalgebraExt;
 use crate::{consts, AirmashGame, Vector2};
 
 #[handler]

--- a/server/src/system/handler/on_player_repel.rs
+++ b/server/src/system/handler/on_player_repel.rs
@@ -1,6 +1,7 @@
 use crate::component::*;
 use crate::config::{MissilePrototypeRef, PlanePrototypeRef};
 use crate::event::{EventStealth, PlayerRepel};
+use crate::util::NalgebraExt;
 use crate::AirmashGame;
 
 #[handler]
@@ -129,7 +130,7 @@ fn repel_players(event: &PlayerRepel, game: &mut AirmashGame) {
       Err(_) => continue,
     };
 
-    let dir = (pos.0 - player_pos.0).normalize();
+    let dir = (pos.0 - player_pos.0).normalized();
     // TODO: The reflect speed constant didn't do what I wanted here so I've bumped
     //       it up to 10. This should probably be reevaluated at some point.
     vel.0 = dir * 10.0;
@@ -173,10 +174,10 @@ fn repel_missiles(event: &PlayerRepel, game: &mut AirmashGame) {
     traj.start = pos.0;
     traj.maxdist -= total_dist;
 
-    let dir = (pos.0 - player_pos.0).normalize();
+    let dir = (pos.0 - player_pos.0).normalized();
 
     vel.0 = dir * vel.0.norm();
-    accel.0 = (-accel.normalize() + dir).normalize() * mob.accel;
+    accel.0 = (-accel.normalized() + dir).normalized() * mob.accel;
     team.0 = player_team.0;
     owner.0 = event.player;
   }

--- a/server/src/system/handler/on_player_respawn.rs
+++ b/server/src/system/handler/on_player_respawn.rs
@@ -2,6 +2,7 @@ use crate::component::*;
 use crate::config::PlanePrototypeRef;
 use crate::event::{PlayerPowerup, PlayerRespawn, PlayerSpawn};
 use crate::resource::{Config, GameConfig};
+use crate::util::NalgebraExt;
 use crate::{AirmashGame, EntitySetBuilder, Vector2};
 
 #[handler]

--- a/server/src/system/handler/on_player_spectate.rs
+++ b/server/src/system/handler/on_player_spectate.rs
@@ -2,6 +2,7 @@ use smallvec::SmallVec;
 
 use crate::component::*;
 use crate::event::PlayerSpectate;
+use crate::util::NalgebraExt;
 use crate::{AirmashGame, Vector2};
 
 #[handler(priority = crate::priority::MEDIUM)]

--- a/server/src/system/physics.rs
+++ b/server/src/system/physics.rs
@@ -1,8 +1,6 @@
 use std::f32::consts::{FRAC_PI_2, PI, TAU};
 use std::time::Duration;
 
-use nalgebra::vector;
-
 use crate::component::*;
 use crate::config::{MissilePrototypeRef, PlanePrototypeRef};
 use crate::event::PlayerJoin;
@@ -91,7 +89,7 @@ fn update_player_positions(game: &mut AirmashGame) {
 
     if let Some(angle) = movement_angle {
       let mult = plane.accel * delta * boost_factor;
-      vel.0 += vector![mult * angle.sin(), mult * -angle.cos()];
+      vel.0 += Vector2::new(mult * angle.sin(), mult * -angle.cos());
     }
 
     let old_vel = vel.0;
@@ -122,7 +120,7 @@ fn update_player_positions(game: &mut AirmashGame) {
     pos.0 += old_vel * delta + (vel.0 - old_vel) * delta * 0.5;
     rot.0 = (rot.0 % TAU + TAU) % TAU;
 
-    let bound = vector![16352.0, 8160.0];
+    let bound = Vector2::new(16352.0, 8160.0);
     if pos.x.abs() > bound.x {
       pos.x = pos.x.signum() * bound.x;
     }
@@ -151,7 +149,7 @@ fn update_missile_positions(game: &mut AirmashGame) {
 
     pos.0 += oldvel * delta + (vel.0 - oldvel) * delta * 0.5;
 
-    let bounds = vector![16384.0, 8192.0];
+    let bounds = Vector2::new(16384.0, 8192.0);
     let size = bounds * 2.0;
 
     if pos.x.abs() > bounds.x {

--- a/server/src/system/physics.rs
+++ b/server/src/system/physics.rs
@@ -7,7 +7,7 @@ use crate::event::PlayerJoin;
 use crate::protocol::server::PlayerUpdate;
 use crate::protocol::Upgrades as ServerUpgrades;
 use crate::resource::*;
-use crate::util::get_current_clock;
+use crate::util::{get_current_clock, NalgebraExt};
 use crate::{AirmashGame, Vector2};
 
 pub fn update(game: &mut AirmashGame) {

--- a/server/src/system/visibility.rs
+++ b/server/src/system/visibility.rs
@@ -1,4 +1,5 @@
-use fxhash::FxHashSet as HashSet;
+use std::collections::HashSet;
+
 use hecs::Entity;
 
 use crate::component::*;

--- a/server/src/system/visibility.rs
+++ b/server/src/system/visibility.rs
@@ -5,6 +5,7 @@ use crate::component::*;
 use crate::event::{EntitySpawn, EventHorizon, MobSpawn, PlayerFire};
 use crate::resource::collision::LayerSpec;
 use crate::resource::{collision as c, GameConfig};
+use crate::util::NalgebraExt;
 use crate::AirmashGame;
 
 def_wrappers! {

--- a/server/src/util/mod.rs
+++ b/server/src/util/mod.rs
@@ -2,8 +2,6 @@
 
 use std::time::{Duration, Instant};
 
-use nalgebra::vector;
-
 use crate::component::{Effects, Upgrades};
 use crate::protocol::Time;
 use crate::resource::*;
@@ -49,5 +47,5 @@ pub fn get_server_upgrades(upgrades: &Upgrades, effects: &Effects) -> crate::pro
 
 pub fn rotate(v: Vector2, angle: f32) -> Vector2 {
   let (sin, cos) = angle.sin_cos();
-  vector![v.x * cos - v.y * sin, v.x * sin + v.y * cos]
+  Vector2::new(v.x * cos - v.y * sin, v.x * sin + v.y * cos)
 }

--- a/server/src/util/mod.rs
+++ b/server/src/util/mod.rs
@@ -47,7 +47,7 @@ pub fn get_server_upgrades(upgrades: &Upgrades, effects: &Effects) -> crate::pro
   }
 }
 
-pub fn rotate(v: Vector2<f32>, angle: f32) -> Vector2<f32> {
+pub fn rotate(v: Vector2, angle: f32) -> Vector2 {
   let (sin, cos) = angle.sin_cos();
   vector![v.x * cos - v.y * sin, v.x * sin + v.y * cos]
 }

--- a/server/src/util/mod.rs
+++ b/server/src/util/mod.rs
@@ -11,8 +11,10 @@ pub(crate) mod escapes;
 mod powerup_spawner;
 pub(crate) mod serde;
 pub mod spectate;
+mod vector;
 
 pub use self::powerup_spawner::PeriodicPowerupSpawner;
+pub use self::vector::NalgebraExt;
 
 pub fn convert_time(dur: Duration) -> Time {
   dur.as_secs_f32() * 60.0

--- a/server/src/util/powerup_spawner.rs
+++ b/server/src/util/powerup_spawner.rs
@@ -14,11 +14,11 @@ pub struct PeriodicPowerupSpawner {
   state: SpawnerState,
   interval: Duration,
   mob: MobType,
-  pos: Vector2<f32>,
+  pos: Vector2,
 }
 
 impl PeriodicPowerupSpawner {
-  pub fn new(mob: MobType, pos: Vector2<f32>, interval: Duration) -> Self {
+  pub fn new(mob: MobType, pos: Vector2, interval: Duration) -> Self {
     Self {
       mob,
       pos,
@@ -27,11 +27,11 @@ impl PeriodicPowerupSpawner {
     }
   }
 
-  pub fn inferno(pos: Vector2<f32>, interval: Duration) -> Self {
+  pub fn inferno(pos: Vector2, interval: Duration) -> Self {
     Self::new(MobType::Inferno, pos, interval)
   }
 
-  pub fn shield(pos: Vector2<f32>, interval: Duration) -> Self {
+  pub fn shield(pos: Vector2, interval: Duration) -> Self {
     Self::new(MobType::Shield, pos, interval)
   }
 }

--- a/server/src/util/serde/mod.rs
+++ b/server/src/util/serde/mod.rs
@@ -30,3 +30,17 @@ pub(crate) mod option_duration {
     Ok(Option::deserialize(de)?.map(Duration::from_secs_f64))
   }
 }
+
+pub(crate) mod vector {
+  use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+  use crate::Vector2;
+
+  pub(crate) fn serialize<S: Serializer>(v: &Vector2, ser: S) -> Result<S::Ok, S::Error> {
+    [v.x, v.y].serialize(ser)
+  }
+
+  pub(crate) fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<Vector2, D::Error> {
+    <[f32; 2]>::deserialize(de).map(From::from)
+  }
+}

--- a/server/src/util/vector.rs
+++ b/server/src/util/vector.rs
@@ -1,0 +1,21 @@
+use ultraviolet::Vec2;
+
+pub trait NalgebraExt {
+  fn zeros() -> Self;
+
+  fn norm(&self) -> f32;
+  fn norm_squared(&self) -> f32;
+}
+
+impl NalgebraExt for Vec2 {
+  fn zeros() -> Self {
+    Self::zero()
+  }
+
+  fn norm(&self) -> f32 {
+    self.mag()
+  }
+  fn norm_squared(&self) -> f32 {
+    self.mag_sq()
+  }
+}

--- a/server/src/worldext.rs
+++ b/server/src/worldext.rs
@@ -3,7 +3,6 @@ use std::time::{Duration, Instant};
 
 use fxhash::FxHashSet as HashSet;
 use hecs::{Entity, EntityBuilder, NoSuchEntity};
-use nalgebra::vector;
 use smallvec::SmallVec;
 
 use crate::component::*;
@@ -13,6 +12,7 @@ use crate::network::{ConnectionId, ConnectionMgr};
 use crate::protocol::{v5, MobType, ServerPacket};
 use crate::resource::collision::LayerSpec;
 use crate::resource::{Config, GameConfig, LastFrame, ThisFrame};
+use crate::util::NalgebraExt;
 use crate::{AirmashGame, Vector2};
 
 /// Info required to spawn a new missile.
@@ -210,18 +210,18 @@ impl AirmashGame {
       let angle = total_angle * frac;
 
       infos.push(FireMissileInfo {
-        pos_offset: vector![
+        pos_offset: Vector2::new(
           start_y + total_offset_y * frac,
-          start_x - total_offset_x * frac
-        ],
+          start_x - total_offset_x * frac,
+        ),
         rot_offset: -angle,
         proto: missile,
       });
       infos.push(FireMissileInfo {
-        pos_offset: vector![
+        pos_offset: Vector2::new(
           start_y - total_offset_y * frac,
-          start_x - total_offset_x * frac
-        ],
+          start_x - total_offset_x * frac,
+        ),
         rot_offset: angle,
         proto: missile,
       });

--- a/server/src/worldext.rs
+++ b/server/src/worldext.rs
@@ -20,7 +20,7 @@ use crate::{AirmashGame, Vector2};
 pub struct FireMissileInfo {
   /// Starting offset of the missile, relative to the plane that is firing it.
   /// This will be rotated into the plane's frame of reference.
-  pub pos_offset: Vector2<f32>,
+  pub pos_offset: Vector2,
   /// Direction that the missile will accelerate in, relative to the direction
   /// the plane is facing when it fires.
   pub rot_offset: f32,
@@ -238,7 +238,7 @@ impl AirmashGame {
   /// entity.
   ///
   /// [`fire_missiles`]: crate::AirmashGame::fire_missiles
-  pub fn spawn_mob(&mut self, mob: MobType, pos: Vector2<f32>, lifetime: Duration) -> Entity {
+  pub fn spawn_mob(&mut self, mob: MobType, pos: Vector2, lifetime: Duration) -> Entity {
     assert!(
       matches!(mob, MobType::Inferno | MobType::Shield | MobType::Upgrade),
       "Can only spawn stationary mobs"
@@ -402,7 +402,7 @@ impl AirmashGame {
 
   /// Send a packet to all players that are within the visible range of the
   /// provided position.
-  pub fn send_to_visible(&self, pos: Vector2<f32>, packet: impl Into<ServerPacket>) {
+  pub fn send_to_visible(&self, pos: Vector2, packet: impl Into<ServerPacket>) {
     self.send_to_entities(EntitySetBuilder::visible(self, pos), packet);
   }
 
@@ -413,12 +413,7 @@ impl AirmashGame {
 
   /// Send a packet to all players on the provided team that are also within
   /// visible range of the provided position.
-  pub fn send_to_team_visible(
-    &self,
-    team: u16,
-    pos: Vector2<f32>,
-    packet: impl Into<ServerPacket>,
-  ) {
+  pub fn send_to_team_visible(&self, team: u16, pos: Vector2, packet: impl Into<ServerPacket>) {
     self.send_to_entities(EntitySetBuilder::team_visible(self, team, pos), packet);
   }
 
@@ -449,7 +444,7 @@ impl EntitySetBuilder {
 
   /// Create an entity set with all players on `team` within the view radius of
   /// `pos`.
-  pub fn team_visible(game: &AirmashGame, team: u16, pos: Vector2<f32>) -> Self {
+  pub fn team_visible(game: &AirmashGame, team: u16, pos: Vector2) -> Self {
     use crate::resource::collision::PlayerPosDb;
 
     let db = game.resources.read::<PlayerPosDb>();
@@ -466,7 +461,7 @@ impl EntitySetBuilder {
   }
 
   /// Create an entity set with all players within the view radius of `pos`.
-  pub fn visible(game: &AirmashGame, pos: Vector2<f32>) -> Self {
+  pub fn visible(game: &AirmashGame, pos: Vector2) -> Self {
     use crate::resource::collision::PlayerPosDb;
 
     let db = game.resources.read::<PlayerPosDb>();

--- a/server/src/worldext.rs
+++ b/server/src/worldext.rs
@@ -1,7 +1,7 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use fxhash::FxHashSet as HashSet;
 use hecs::{Entity, EntityBuilder, NoSuchEntity};
 use smallvec::SmallVec;
 

--- a/server/src/worldext.rs
+++ b/server/src/worldext.rs
@@ -111,7 +111,7 @@ impl AirmashGame {
 
       // Rotate starting angle 90 degrees so that it's inline with the plane. Change
       // this and missiles will shoot sideways
-      let dir = vector![rot.sin(), -rot.cos()];
+      let dir = Vector2::new(rot.sin(), -rot.cos());
       let vel = dir * (missile.base_speed + speed * missile.inherit_factor) * upg_factor;
 
       let mut builder = crate::defaults::build_default_missile();
@@ -200,7 +200,7 @@ impl AirmashGame {
 
     let mut infos = SmallVec::<[_; 3]>::new();
     infos.push(FireMissileInfo {
-      pos_offset: vector![start_y, start_x],
+      pos_offset: Vector2::new(start_y, start_x),
       rot_offset: 0.0,
       proto: missile,
     });

--- a/server/tests/behaviour/despawn.rs
+++ b/server/tests/behaviour/despawn.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use airmash_server::util::NalgebraExt;
 use airmash_server::Vector2;
 use server::component::*;
 use server::protocol::{DespawnType, ServerPacket};

--- a/server/tests/behaviour/powerups.rs
+++ b/server/tests/behaviour/powerups.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use airmash_server::util::NalgebraExt;
 use server::component::*;
 use server::protocol::{server as s, ServerPacket};
 use server::test::TestGame;

--- a/server/tests/behaviour/prowler.rs
+++ b/server/tests/behaviour/prowler.rs
@@ -1,7 +1,7 @@
 use airmash_server::resource::GameConfig;
-use nalgebra::vector;
 use server::component::*;
 use server::protocol::KeyCode;
+use server::Vector2;
 
 #[test]
 fn prowler_decloak_on_hit() {
@@ -30,11 +30,11 @@ fn prowler_decloak_on_hit() {
 
   game
     .world
-    .insert(ent1, (Position(vector![0.0, -250.0]), prowler))
+    .insert(ent1, (Position(Vector2::new(0.0, -250.0)), prowler))
     .unwrap();
   game
     .world
-    .insert_one(ent2, Position(vector![0.0, 0.0]))
+    .insert_one(ent2, Position(Vector2::new(0.0, 0.0)))
     .unwrap();
 
   client1.send_key(KeyCode::Special, true);

--- a/server/tests/behaviour/upgrades.rs
+++ b/server/tests/behaviour/upgrades.rs
@@ -4,6 +4,7 @@ use airmash_protocol::ServerPacket;
 use airmash_server::component::*;
 use airmash_server::event::PlayerKilled;
 use airmash_server::resource::GameConfig;
+use airmash_server::util::NalgebraExt;
 use airmash_server::{FireMissileInfo, Vector2};
 use server::test::TestGame;
 

--- a/server/tests/behaviour/visibility.rs
+++ b/server/tests/behaviour/visibility.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use airmash_protocol::{KeyCode, MobType, ServerPacket};
 use airmash_server::component::Position;
 use airmash_server::resource::GameConfig;
+use airmash_server::util::NalgebraExt;
 use airmash_server::Vector2;
 use server::test::TestGame;
 use server_config::GamePrototype;

--- a/server/tests/behaviour/visibility.rs
+++ b/server/tests/behaviour/visibility.rs
@@ -4,7 +4,6 @@ use airmash_protocol::{KeyCode, MobType, ServerPacket};
 use airmash_server::component::Position;
 use airmash_server::resource::GameConfig;
 use airmash_server::Vector2;
-use nalgebra::vector;
 use server::test::TestGame;
 use server_config::GamePrototype;
 
@@ -28,7 +27,7 @@ fn out_of_visibility_missiles_properly_deleted() {
 
   let view_radius = game.resources.read::<GameConfig>().view_radius;
 
-  game.world.get_mut::<Position>(ent2).unwrap().0 = vector![0.0, -view_radius + 1.0];
+  game.world.get_mut::<Position>(ent2).unwrap().0 = Vector2::new(0.0, -view_radius + 1.0);
   game.run_count(60);
 
   client2.send_key(KeyCode::Fire, true);
@@ -76,9 +75,9 @@ fn out_of_visibility_collision() {
   let id2 = ent2.id() as u16;
 
   // There is a mountain at (x: -252, y: -1504) with r = 60
-  let object = vector![-252.0, -1504.0];
+  let object = Vector2::new(-252.0, -1504.0);
 
-  let pos = vector![object.x, object.y - offset];
+  let pos = Vector2::new(object.x, object.y - offset);
 
   game.world.get_mut::<Position>(ent1).unwrap().0 = pos;
   game.world.get_mut::<Position>(ent2).unwrap().0 = pos;


### PR DESCRIPTION
We use ~3 things total from nalgebra, it is not worth having all that compile time for what we use it for. This PR switches everything over to using `ultraviolet` and in the meantime also removed a couple of unused dependencies.