### PR TITLE
Ensure that players are given a spawn shield when they initially join

### DIFF
--- a/server/src/system/handler/on_player_respawn.rs
+++ b/server/src/system/handler/on_player_respawn.rs
@@ -1,7 +1,6 @@
 use crate::component::*;
 use crate::config::PlanePrototypeRef;
-use crate::event::{PlayerPowerup, PlayerRespawn, PlayerSpawn};
-use crate::resource::Config;
+use crate::event::{PlayerRespawn, PlayerSpawn};
 use crate::util::NalgebraExt;
 use crate::{AirmashGame, EntitySetBuilder, Vector2};
 
@@ -35,8 +34,6 @@ fn send_packet(event: &PlayerRespawn, game: &mut AirmashGame) {
 // changes don't have theirs get stomped over.
 #[handler(priority = crate::priority::PRE_LOGIN)]
 fn reset_player(event: &PlayerRespawn, game: &mut AirmashGame) {
-  let config = game.resources.read::<Config>();
-
   let mut query = match game.world.query_one::<(
     &mut Position,
     &mut Velocity,
@@ -88,18 +85,6 @@ fn reset_player(event: &PlayerRespawn, game: &mut AirmashGame) {
   spectating.0 = false;
   active.0 = false;
   spectgt.0 = None;
-
-  let proto = config.powerups.get("spawn-shield").copied();
-
-  drop(config);
-  drop(query);
-
-  if let Some(proto) = proto {
-    game.dispatch(PlayerPowerup {
-      player: event.player,
-      powerup: proto,
-    });
-  }
 }
 
 #[handler]

--- a/server/src/system/handler/on_player_spawn.rs
+++ b/server/src/system/handler/on_player_spawn.rs
@@ -1,6 +1,6 @@
 use crate::component::*;
-use crate::event::PlayerSpawn;
-use crate::resource::GameConfig;
+use crate::event::{PlayerPowerup, PlayerSpawn};
+use crate::resource::{Config, GameConfig};
 use crate::AirmashGame;
 
 // If GameConfig::always_upgraded is true then we need to stamp over the set of
@@ -20,4 +20,21 @@ fn override_player_upgrades(evt: &PlayerSpawn, game: &mut AirmashGame) {
   upgrades.defense = 5;
   upgrades.energy = 5;
   upgrades.missile = 5;
+}
+
+#[handler]
+fn give_spawn_shield(event: &PlayerSpawn, game: &mut AirmashGame) {
+  let proto = game
+    .resources
+    .read::<Config>()
+    .powerups
+    .get("spawn-shield")
+    .copied();
+
+  if let Some(proto) = proto {
+    game.dispatch(PlayerPowerup {
+      player: event.player,
+      powerup: proto,
+    });
+  }
 }

--- a/server/tests/behaviour/powerups.rs
+++ b/server/tests/behaviour/powerups.rs
@@ -83,3 +83,33 @@ fn inferno_slows_down_plane() {
     .any(|p| p.upgrades.inferno);
   assert!(has_inferno);
 }
+
+#[test]
+fn first_spawn_has_2s_shield() {
+  let (mut game, mut mock) = TestGame::new();
+
+  let mut client = mock.open();
+  client.login("test", &mut game);
+  game.run_once();
+
+  assert!(client.packets().any(|p| matches!(
+    p,
+    ServerPacket::PlayerPowerup(s::PlayerPowerup {
+      ty: PowerupType::Shield,
+      ..
+    })
+  )));
+
+  game.run_for(Duration::from_secs(3));
+  let _ = client.packets().count();
+  game.run_for(Duration::from_secs(3));
+
+  let no_shield = !client
+    .packets()
+    .filter_map(|p| match p {
+      ServerPacket::PlayerUpdate(p) => Some(p),
+      _ => None,
+    })
+    .any(|p| p.upgrades.shield);
+  assert!(no_shield);
+}


### PR DESCRIPTION
The problem was that spawn shields were only given as part of the `PlayerRespawn` event which isn't triggered when a player joins. Instead, this moves that to `PlayerSpawn` which is also fired when a player joins.

Fixes #215 