### PR TITLE
Standardize naming of the server crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,19 +38,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "airmash-protocol"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f34bd68b89b81154bf6f0047b78fcb1fb0929d7c05595c7939c151bf218dd2"
-dependencies = [
- "bstr",
- "mint",
- "serde-feature-hack",
- "serde_json",
-]
-
-[[package]]
-name = "airmash-server"
+name = "airmash"
 version = "0.1.0"
 dependencies = [
  "airmash-protocol",
@@ -81,10 +69,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "airmash-protocol"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f34bd68b89b81154bf6f0047b78fcb1fb0929d7c05595c7939c151bf218dd2"
+dependencies = [
+ "bstr",
+ "mint",
+ "serde-feature-hack",
+ "serde_json",
+]
+
+[[package]]
 name = "airmash-server-base"
 version = "0.0.1"
 dependencies = [
- "airmash-server",
+ "airmash",
  "clap",
  "env_logger",
  "log",
@@ -94,7 +94,7 @@ dependencies = [
 name = "airmash-server-ctf"
 version = "0.0.1"
 dependencies = [
- "airmash-server",
+ "airmash",
  "bstr",
  "clap",
  "env_logger",
@@ -109,7 +109,7 @@ dependencies = [
 name = "airmash-server-ffa"
 version = "0.0.1"
 dependencies = [
- "airmash-server",
+ "airmash",
  "clap",
  "color-backtrace",
  "env_logger",

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -12,8 +12,4 @@ edition = "2018"
 log = "0.4"
 env_logger = "0.9"
 clap = "3.2.6"
-
-[dependencies.airmash]
-path="../server"
-package = "airmash-server"
-features = ["mt-network"]
+airmash = { path="../server", features = ["mt-network"] }

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -9,7 +9,11 @@ repository = 'https://github.com/steamroller-airmash/airmash-server'
 edition = "2018"
 
 [dependencies]
-airmash-server = { path='../server' }
 log = "0.4"
 env_logger = "0.9"
 clap = "3.2.6"
+
+[dependencies.airmash]
+path="../server"
+package = "airmash-server"
+features = ["mt-network"]

--- a/base/src/main.rs
+++ b/base/src/main.rs
@@ -1,8 +1,8 @@
 use std::env;
 
-use airmash_server::protocol::GameType;
-use airmash_server::resource::RegionName;
-use airmash_server::*;
+use airmash::protocol::GameType;
+use airmash::resource::RegionName;
+use airmash::*;
 use clap::arg;
 
 fn set_default_var(name: &str, value: &str) {
@@ -39,9 +39,9 @@ fn main() {
   game.resources.insert(GameType::FFA);
 
   // Use the FFA scoreboard.
-  airmash_server::system::ffa::register_all(&mut game);
+  airmash::system::ffa::register_all(&mut game);
 
-  let mut config = airmash_server::config::GamePrototype::default();
+  let mut config = airmash::config::GamePrototype::default();
   if let Some(path) = matches.value_of("config") {
     let script = match std::fs::read_to_string(path) {
       Ok(script) => script,
@@ -58,7 +58,7 @@ fn main() {
 
   game
     .resources
-    .insert(airmash_server::resource::Config::new(config).unwrap());
+    .insert(airmash::resource::Config::new(config).unwrap());
 
   game.run_until_shutdown();
 }

--- a/ctf/Cargo.toml
+++ b/ctf/Cargo.toml
@@ -18,8 +18,5 @@ bstr = "0.2"
 
 lazy_static = "1.4"
 smallvec = "1.6"
+airmash = { path="../server", features = ["mt-network"] }
 
-[dependencies.airmash]
-path="../server"
-package = "airmash-server"
-features = ["mt-network"]

--- a/ffa/Cargo.toml
+++ b/ffa/Cargo.toml
@@ -9,10 +9,14 @@ repository = 'https://github.com/steamroller-airmash/airmash-server'
 edition = "2018"
 
 [dependencies]
-server = { path="../server", package="airmash-server" }
 log = "0.4"
 env_logger = "0.9"
 rand = "0.8"
 clap = "3.2.6"
 serde = "1.0"
 color-backtrace = "0.5"
+
+[dependencies.airmash]
+path="../server"
+package = "airmash-server"
+features = ["mt-network"]

--- a/ffa/Cargo.toml
+++ b/ffa/Cargo.toml
@@ -15,8 +15,5 @@ rand = "0.8"
 clap = "3.2.6"
 serde = "1.0"
 color-backtrace = "0.5"
+airmash = { path="../server", features = ["mt-network"] }
 
-[dependencies.airmash]
-path="../server"
-package = "airmash-server"
-features = ["mt-network"]

--- a/ffa/src/main.rs
+++ b/ffa/src/main.rs
@@ -1,11 +1,11 @@
 use std::env;
 use std::time::Duration;
 
+use airmash::protocol::GameType;
+use airmash::resource::RegionName;
+use airmash::util::PeriodicPowerupSpawner;
+use airmash::*;
 use clap::arg;
-use server::protocol::GameType;
-use server::resource::RegionName;
-use server::util::PeriodicPowerupSpawner;
-use server::*;
 
 mod systems;
 
@@ -43,7 +43,7 @@ fn main() {
   game.resources.insert(GameType::FFA);
 
   // Use the provided FFA scoreboard systems.
-  server::system::ffa::register_all(&mut game);
+  airmash::system::ffa::register_all(&mut game);
 
   // Inferno in Europe
   game.register(PeriodicPowerupSpawner::inferno(
@@ -59,7 +59,7 @@ fn main() {
     Duration::from_secs(105),
   ));
 
-  let mut config = server::config::GamePrototype::default();
+  let mut config = airmash::config::GamePrototype::default();
   if let Some(path) = matches.value_of("config") {
     let script = match std::fs::read_to_string(path) {
       Ok(script) => script,
@@ -76,7 +76,7 @@ fn main() {
 
   game
     .resources
-    .insert(server::resource::Config::new(config).unwrap());
+    .insert(airmash::resource::Config::new(config).unwrap());
 
   game.run_until_shutdown();
 }

--- a/ffa/src/systems.rs
+++ b/ffa/src/systems.rs
@@ -1,7 +1,7 @@
-use server::component::*;
-use server::event::{PlayerJoin, PlayerRespawn};
-use server::resource::collision::{LayerSpec, Terrain};
-use server::{AirmashGame, Vector2};
+use airmash::component::*;
+use airmash::event::{PlayerJoin, PlayerRespawn};
+use airmash::resource::collision::{LayerSpec, Terrain};
+use airmash::{AirmashGame, Vector2};
 
 const SPAWN_TOP_RIGHT: Vector2 = Vector2::new(-1325.0, -4330.0);
 const SPAWN_SIZE: Vector2 = Vector2::new(3500.0, 2500.0);
@@ -23,7 +23,7 @@ pub fn select_spawn_position(game: &AirmashGame) -> Vector2 {
   }
 }
 
-#[server::handler(priority = server::priority::PRE_LOGIN)]
+#[airmash::handler(priority = airmash::priority::PRE_LOGIN)]
 fn choose_join_position(event: &PlayerJoin, game: &mut AirmashGame) {
   let spawn_pos = select_spawn_position(game);
 
@@ -32,7 +32,7 @@ fn choose_join_position(event: &PlayerJoin, game: &mut AirmashGame) {
   }
 }
 
-#[server::handler(priority = server::priority::HIGH)]
+#[airmash::handler(priority = airmash::priority::HIGH)]
 fn choose_respawn_position(event: &PlayerRespawn, game: &mut AirmashGame) {
   let spawn_pos = select_spawn_position(game);
 

--- a/server-macros/src/handler.rs
+++ b/server-macros/src/handler.rs
@@ -55,8 +55,8 @@ pub fn handler(
 
 fn impl_handler(item: ItemFn, args: MacroArgs) -> Result<TokenStream> {
   let name = &item.sig.ident;
-  let krate = match proc_macro_crate::crate_name("airmash-server").unwrap_or(FoundCrate::Itself) {
-    FoundCrate::Itself => Ident::new("airmash_server", Span::call_site()),
+  let krate = match proc_macro_crate::crate_name("airmash").unwrap_or(FoundCrate::Itself) {
+    FoundCrate::Itself => Ident::new("airmash", Span::call_site()),
     FoundCrate::Name(name) => Ident::new(&name, Span::call_site()),
   };
 

--- a/server-macros/src/lib.rs
+++ b/server-macros/src/lib.rs
@@ -22,7 +22,7 @@ mod handler;
 /// # Example
 /// ```ignore
 /// # struct MyEvent;
-/// # struct AirmashGame; // We can't import airmash_server here
+/// # struct AirmashGame; // We can't import airmash here
 /// const MY_CUSTOM_PRIORITY: i32 = 335;
 ///
 /// // Here we create an event handler with the default priority.

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "airmash-server"
+name = "airmash"
 version = "0.1.0"
 edition = "2018"
 

--- a/server/src/event/mod.rs
+++ b/server/src/event/mod.rs
@@ -19,7 +19,7 @@
 //! Creating an event handler via the [`handler`] macro will look something like
 //! this:
 //! ```
-//! # use airmash_server::{handler, AirmashGame};
+//! # use airmash::{handler, AirmashGame};
 //! # struct InsertEventHere;
 //! #[handler]
 //! fn my_custom_handler(event: &InsertEventHere, game: &mut AirmashGame) {
@@ -35,7 +35,7 @@
 //! To do this we must first define a handler and then later on register an
 //! instance of it with whatever [`AirmashGame`] instance we choose.
 //! ```
-//! # use airmash_server::{EventHandler, AirmashGame, event::Frame};
+//! # use airmash::{EventHandler, AirmashGame, event::Frame};
 //! #[derive(Default)]
 //! pub struct CountFrames(usize);
 //!

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -23,7 +23,7 @@ extern crate log;
 #[macro_use]
 extern crate server_macros;
 
-extern crate self as airmash_server;
+extern crate self as airmash;
 
 #[macro_use]
 mod macros;

--- a/server/src/macros.rs
+++ b/server/src/macros.rs
@@ -84,8 +84,8 @@ macro_rules! def_wrapper_resources {
       const _: () = {
         #[crate::handler]
         fn register_resource(
-          _: &airmash_server::event::ServerStartup,
-          world: &mut airmash_server::AirmashGame
+          _: &airmash::event::ServerStartup,
+          world: &mut airmash::AirmashGame
         ) {
           if world.resources.get::<$nty>().is_none() {
             world.resources.insert(<$nty>::default());

--- a/server/tests/all_tests.rs
+++ b/server/tests/all_tests.rs
@@ -1,4 +1,4 @@
-extern crate airmash_server as server;
+// extern crate airmash as server;
 
 #[macro_use]
 extern crate approx;

--- a/server/tests/behaviour/admin.rs
+++ b/server/tests/behaviour/admin.rs
@@ -1,6 +1,6 @@
-use airmash_server::component::Position;
-use airmash_server::resource::GameConfig;
-use server::protocol::client as c;
+use airmash::component::Position;
+use airmash::protocol::client as c;
+use airmash::resource::GameConfig;
 
 #[test]
 fn admin_teleport() {

--- a/server/tests/behaviour/despawn.rs
+++ b/server/tests/behaviour/despawn.rs
@@ -1,11 +1,11 @@
 use std::time::Duration;
 
-use airmash_server::util::NalgebraExt;
-use airmash_server::Vector2;
-use server::component::*;
-use server::protocol::{DespawnType, ServerPacket};
-use server::test::TestGame;
-use server_config::GamePrototype;
+use airmash::component::*;
+use airmash::config::GamePrototype;
+use airmash::protocol::{DespawnType, ServerPacket};
+use airmash::test::TestGame;
+use airmash::util::NalgebraExt;
+use airmash::Vector2;
 
 #[test]
 fn upgrade_despawns_on_time() {

--- a/server/tests/behaviour/powerups.rs
+++ b/server/tests/behaviour/powerups.rs
@@ -1,10 +1,10 @@
 use std::time::Duration;
 
-use airmash_server::util::NalgebraExt;
-use server::component::*;
-use server::protocol::{server as s, ServerPacket};
-use server::test::TestGame;
-use server::Vector2;
+use airmash::component::*;
+use airmash::protocol::{server as s, ServerPacket};
+use airmash::test::TestGame;
+use airmash::util::NalgebraExt;
+use airmash::Vector2;
 
 #[test]
 fn player_is_upgraded_on_collision_with_upgrade() {

--- a/server/tests/behaviour/prowler.rs
+++ b/server/tests/behaviour/prowler.rs
@@ -1,7 +1,7 @@
-use server::component::*;
-use server::protocol::KeyCode;
-use server::resource::Config;
-use server::Vector2;
+use airmash::component::*;
+use airmash::protocol::KeyCode;
+use airmash::resource::Config;
+use airmash::Vector2;
 
 #[test]
 fn prowler_decloak_on_hit() {

--- a/server/tests/behaviour/respawn.rs
+++ b/server/tests/behaviour/respawn.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
-use server::protocol::{PlaneType, ServerPacket};
-use server::test::TestGame;
+use airmash::protocol::{PlaneType, ServerPacket};
+use airmash::test::TestGame;
 
 #[test]
 fn respawn_as_mohawk() {

--- a/server/tests/behaviour/shoot.rs
+++ b/server/tests/behaviour/shoot.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
-use server::protocol::{MobType, ServerPacket};
-use server::test::TestGame;
+use airmash::protocol::{MobType, ServerPacket};
+use airmash::test::TestGame;
 
 #[test]
 fn predator_fires_predator_missile() {

--- a/server/tests/behaviour/upgrades.rs
+++ b/server/tests/behaviour/upgrades.rs
@@ -1,12 +1,12 @@
 use std::time::Duration;
 
+use airmash::component::*;
+use airmash::event::PlayerKilled;
+use airmash::resource::{Config, GameConfig};
+use airmash::test::TestGame;
+use airmash::util::NalgebraExt;
+use airmash::{FireMissileInfo, Vector2};
 use airmash_protocol::ServerPacket;
-use airmash_server::component::*;
-use airmash_server::event::PlayerKilled;
-use airmash_server::resource::{Config, GameConfig};
-use airmash_server::util::NalgebraExt;
-use airmash_server::{FireMissileInfo, Vector2};
-use server::test::TestGame;
 
 #[test]
 fn player_does_not_drop_upgrade_when_not_configured() {

--- a/server/tests/behaviour/visibility.rs
+++ b/server/tests/behaviour/visibility.rs
@@ -1,12 +1,12 @@
 use std::time::Duration;
 
-use airmash_protocol::{KeyCode, MobType, ServerPacket};
-use airmash_server::component::Position;
-use airmash_server::resource::Config;
-use airmash_server::util::NalgebraExt;
-use airmash_server::Vector2;
-use server::test::TestGame;
-use server_config::GamePrototype;
+use airmash::component::Position;
+use airmash::config::GamePrototype;
+use airmash::protocol::{KeyCode, MobType, ServerPacket};
+use airmash::resource::Config;
+use airmash::test::TestGame;
+use airmash::util::NalgebraExt;
+use airmash::Vector2;
 
 /// If a player is at the very edge of another player's horizon then
 /// LeaveHorizon packets may not be sent correctly because the missile might be

--- a/server/tests/task.rs
+++ b/server/tests/task.rs
@@ -1,9 +1,9 @@
 use std::time::Duration;
 
+use airmash::protocol::server::ServerMessage;
+use airmash::resource::TaskScheduler;
+use airmash::test::*;
 use airmash_protocol::ServerPacket;
-use airmash_server::protocol::server::ServerMessage;
-use airmash_server::resource::TaskScheduler;
-use airmash_server::test::*;
 
 #[test]
 fn tasks_obey_test_time() {

--- a/server/tests/utils/mod.rs
+++ b/server/tests/utils/mod.rs
@@ -1,6 +1,6 @@
+use airmash::protocol::client as c;
+use airmash::test::{MockConnection, MockConnectionEndpoint, TestGame};
 use airmash_protocol::ServerPacket;
-use server::protocol::client as c;
-use server::test::{MockConnection, MockConnectionEndpoint, TestGame};
 
 pub fn create_login_packet(name: &str) -> c::Login {
   c::Login {


### PR DESCRIPTION
It was referred to by 3 different names across each of the crates. This PR changes things to refer to it as `airmash` everywhere.